### PR TITLE
[codex] 修复 API 插件 trace 属性冲突

### DIFF
--- a/bkflow/pipeline_plugins/components/collections/uniform_api/span.py
+++ b/bkflow/pipeline_plugins/components/collections/uniform_api/span.py
@@ -1,0 +1,54 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
+Copyright (C) 2024 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+
+to the current version of the project delivered to anyone in the future.
+"""
+
+UNIFORM_API_PLUGIN_API_META_INPUT_KEY = "uniform_api_plugin_api_meta"
+
+
+def build_api_meta_span_attributes(api_meta):
+    """从 API 插件元信息中提取适合检索的 Span 属性"""
+    if not isinstance(api_meta, dict):
+        return {}
+
+    category = api_meta.get("category") or {}
+    attributes = {
+        "api_id": api_meta.get("id"),
+        "api_name": api_meta.get("name"),
+        "api_key": api_meta.get("api_key"),
+    }
+
+    if isinstance(category, dict):
+        attributes.update(
+            {
+                "api_category_id": category.get("id"),
+                "api_category_name": category.get("name"),
+            }
+        )
+
+    return {key: value for key, value in attributes.items() if value not in (None, "")}
+
+
+def get_uniform_api_span_attributes(data):
+    """获取 API 插件通用 Span 属性"""
+    attributes = {
+        "url": data.get_one_of_inputs("uniform_api_plugin_url", ""),
+        "http_method": data.get_one_of_inputs("uniform_api_plugin_method", ""),
+    }
+    api_meta = data.get_one_of_inputs(UNIFORM_API_PLUGIN_API_META_INPUT_KEY, {})
+    attributes.update(build_api_meta_span_attributes(api_meta))
+    return attributes

--- a/bkflow/pipeline_plugins/components/collections/uniform_api/v2_0_0.py
+++ b/bkflow/pipeline_plugins/components/collections/uniform_api/v2_0_0.py
@@ -16,6 +16,7 @@ We undertake not to change the open source license (MIT license) applicable
 
 to the current version of the project delivered to anyone in the future.
 """
+
 import copy
 from typing import Optional, Union
 
@@ -30,6 +31,10 @@ from bkflow.contrib.api.collections.interface import InterfaceModuleClient
 from bkflow.pipeline_plugins.components.collections.base import (
     BKFlowBaseService,
     StepIntervalGenerator,
+)
+from bkflow.pipeline_plugins.components.collections.uniform_api.span import (
+    UNIFORM_API_PLUGIN_API_META_INPUT_KEY,
+    get_uniform_api_span_attributes,
 )
 from bkflow.pipeline_plugins.query.uniform_api.utils import UniformAPIClient
 from bkflow.pipeline_plugins.utils import convert_dict_value
@@ -85,12 +90,7 @@ class UniformAPIService(BKFlowBaseService):
     def _get_span_attributes(self, data, parent_data):
         """覆盖基类方法，添加API插件特有的属性"""
         attributes = super()._get_span_attributes(data, parent_data)
-        attributes.update(
-            {
-                "url": data.get_one_of_inputs("uniform_api_plugin_url", ""),
-                "method": data.get_one_of_inputs("uniform_api_plugin_method", ""),
-            }
-        )
+        attributes.update(get_uniform_api_span_attributes(data))
         return attributes
 
     def plugin_execute(self, data, parent_data):
@@ -133,6 +133,7 @@ class UniformAPIService(BKFlowBaseService):
         polling = api_data.pop("uniform_api_plugin_polling", None)
         callback = api_data.pop("uniform_api_plugin_callback", None)
         method = api_data.pop("uniform_api_plugin_method")
+        api_data.pop(UNIFORM_API_PLUGIN_API_META_INPUT_KEY, None)
         resp_data_path: str = api_data.pop("response_data_path", None)
         # 获取空间相关配置信息
         interface_client = InterfaceModuleClient()

--- a/bkflow/pipeline_plugins/components/collections/uniform_api/v3_0_0.py
+++ b/bkflow/pipeline_plugins/components/collections/uniform_api/v3_0_0.py
@@ -16,6 +16,7 @@ We undertake not to change the open source license (MIT license) applicable
 
 to the current version of the project delivered to anyone in the future.
 """
+
 import copy
 from typing import Optional, Tuple, Union
 
@@ -37,6 +38,10 @@ from bkflow.pipeline_plugins.components.collections.uniform_api.credential_handl
     CredentialKeyUserProvidedHandler,
     DefaultCredentialHandler,
     SpaceCredentialHandler,
+)
+from bkflow.pipeline_plugins.components.collections.uniform_api.span import (
+    UNIFORM_API_PLUGIN_API_META_INPUT_KEY,
+    get_uniform_api_span_attributes,
 )
 from bkflow.pipeline_plugins.query.uniform_api.utils import UniformAPIClient
 from bkflow.pipeline_plugins.utils import convert_dict_value
@@ -92,12 +97,7 @@ class UniformAPIService(BKFlowBaseService):
     def _get_span_attributes(self, data, parent_data):
         """覆盖基类方法，添加API插件特有的属性"""
         attributes = super()._get_span_attributes(data, parent_data)
-        attributes.update(
-            {
-                "url": data.get_one_of_inputs("uniform_api_plugin_url", ""),
-                "method": data.get_one_of_inputs("uniform_api_plugin_method", ""),
-            }
-        )
+        attributes.update(get_uniform_api_span_attributes(data))
         return attributes
 
     def plugin_execute(self, data, parent_data):
@@ -343,6 +343,7 @@ class UniformAPIService(BKFlowBaseService):
         callback = api_data.pop("uniform_api_plugin_callback", None)
         method = api_data.pop("uniform_api_plugin_method")
         credential_key = api_data.pop("uniform_api_plugin_credential_key", None)
+        api_data.pop(UNIFORM_API_PLUGIN_API_META_INPUT_KEY, None)
         resp_data_path: str = api_data.pop("response_data_path", None)
         # 获取空间相关配置信息
         interface_client = InterfaceModuleClient()

--- a/bkflow/pipeline_web/parser/format.py
+++ b/bkflow/pipeline_web/parser/format.py
@@ -17,7 +17,6 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 
-
 import copy
 
 from bamboo_engine.template import Template
@@ -25,6 +24,9 @@ from pipeline import exceptions
 from pipeline.core.data import library, var
 from pipeline.validators.utils import format_node_io_to_list
 
+from bkflow.pipeline_plugins.components.collections.uniform_api.span import (
+    UNIFORM_API_PLUGIN_API_META_INPUT_KEY,
+)
 from bkflow.pipeline_web.constants import PWE
 
 
@@ -50,6 +52,13 @@ def format_web_data_to_pipeline(web_pipeline: dict, is_subprocess: bool = False)
     for act_id, act in list(pipeline_tree["activities"].items()):
         if act["type"] == "ServiceActivity":
             act_data = act["component"].pop("data")
+            if act["component"].get("code") == "uniform_api" and act["component"].get("api_meta"):
+                act_data[UNIFORM_API_PLUGIN_API_META_INPUT_KEY] = {
+                    "type": "plain",
+                    "value": act["component"]["api_meta"],
+                    "is_param": False,
+                    "need_render": False,
+                }
 
             all_inputs = format_data_to_pipeline_inputs(act_data, classification["data_inputs"])
             act["component"]["inputs"] = {key: value for key, value in list(all_inputs.items()) if key in act_data}

--- a/bkflow/utils/trace.py
+++ b/bkflow/utils/trace.py
@@ -9,6 +9,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 import copy
 import enum
 import logging
@@ -572,11 +573,11 @@ def plugin_method_span(
                 kind=SpanKind.INTERNAL,
             )
 
-            span.set_attribute(f"{platform_code}.plugin.method", method_name)
             for key, value in attributes.items():
                 if value is not None:
                     span.set_attribute(f"{platform_code}.plugin.{key}", str(value))
 
+            span.set_attribute(f"{platform_code}.plugin.method", method_name)
             span.set_attribute(f"{platform_code}.plugin.success", result.success)
             if result.success:
                 span.set_status(Status(StatusCode.OK))

--- a/tests/engine/utils/test_trace.py
+++ b/tests/engine/utils/test_trace.py
@@ -16,6 +16,7 @@ We undertake not to change the open source license (MIT license) applicable
 
 to the current version of the project delivered to anyone in the future.
 """
+
 import time
 from unittest import mock
 
@@ -191,6 +192,28 @@ class TestPluginMethodSpan:
         ) as span_result:
             assert span_result is not None
             assert span_result.success is True
+
+    @override_settings(ENABLE_OTEL_TRACE=True)
+    def test_plugin_method_span_keeps_lifecycle_method_when_plugin_attrs_include_method(self, mocker):
+        """插件属性包含 method 时，方法 Span 仍保留 execute/schedule 语义"""
+        span = mocker.MagicMock()
+        span.attributes = {}
+        span.set_attribute.side_effect = lambda key, value: span.attributes.__setitem__(key, value)
+        tracer = mocker.MagicMock()
+        tracer.start_span.return_value = span
+        mocker.patch("bkflow.utils.trace.trace.get_tracer", return_value=tracer)
+
+        with plugin_method_span(
+            method_name="schedule",
+            plugin_name="uniform_api",
+            method="POST",
+            http_method="POST",
+            task_id="123",
+        ):
+            pass
+
+        assert span.attributes["bkflow.plugin.method"] == "schedule"
+        assert span.attributes["bkflow.plugin.http_method"] == "POST"
 
 
 class TestStartPluginSpan:

--- a/tests/interface/pipeline_web/parser/format/test_format_web_data_to_pipeline.py
+++ b/tests/interface/pipeline_web/parser/format/test_format_web_data_to_pipeline.py
@@ -17,7 +17,6 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 
-
 import json
 
 from django.test import TestCase
@@ -2616,3 +2615,62 @@ class FormatWebDataToPipelineTestCase(TestCase):
         # 由于 mock 组件可能导致详细断言失败，这里只验证核心结构
         self.assertIsInstance(result["data"]["inputs"], dict)
         self.assertIsInstance(result["data"]["outputs"], list)
+
+    def test_uniform_api_api_meta_injected_to_component_inputs(self):
+        """新版 API 插件的 api_meta 会注入为运行时隐藏输入"""
+        api_meta = {
+            "id": "sops_api_001",
+            "name": "流程执行",
+            "meta_url": "http://example.com/meta",
+            "api_key": "sops_execute",
+            "category": {"id": "cat_1", "name": "标准运维"},
+        }
+        web_tree = {
+            "id": "pipeline",
+            "activities": {
+                "node_1": {
+                    "id": "node_1",
+                    "type": "ServiceActivity",
+                    "name": "api node",
+                    "incoming": ["flow_start_node"],
+                    "outgoing": ["flow_node_end"],
+                    "error_ignorable": False,
+                    "component": {
+                        "code": "uniform_api",
+                        "version": "v3.0.0",
+                        "api_meta": api_meta,
+                        "data": {
+                            "uniform_api_plugin_url": {
+                                "hook": False,
+                                "value": "http://example.com/api",
+                            },
+                            "uniform_api_plugin_method": {"hook": False, "value": "POST"},
+                        },
+                    },
+                }
+            },
+            "constants": {},
+            "outputs": [],
+            "flows": {
+                "flow_start_node": {
+                    "id": "flow_start_node",
+                    "source": "start",
+                    "target": "node_1",
+                },
+                "flow_node_end": {
+                    "id": "flow_node_end",
+                    "source": "node_1",
+                    "target": "end",
+                },
+            },
+            "gateways": {},
+            "start_event": {"id": "start", "type": "EmptyStartEvent", "incoming": [], "outgoing": ["flow_start_node"]},
+            "end_event": {"id": "end", "type": "EmptyEndEvent", "incoming": ["flow_node_end"], "outgoing": []},
+        }
+
+        result = format_web_data_to_pipeline(web_tree)
+
+        inputs = result["activities"]["node_1"]["component"]["inputs"]
+        self.assertEqual(inputs["uniform_api_plugin_api_meta"]["value"], api_meta)
+        self.assertFalse(inputs["uniform_api_plugin_api_meta"]["is_param"])
+        self.assertFalse(inputs["uniform_api_plugin_api_meta"]["need_render"])

--- a/tests/plugins/components/collections/uniform_api_test/test_v2_0_0.py
+++ b/tests/plugins/components/collections/uniform_api_test/test_v2_0_0.py
@@ -9,6 +9,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 from unittest.mock import MagicMock
 
 from django.test import TestCase
@@ -22,6 +23,7 @@ from pipeline.component_framework.test import (
 
 from bkflow.pipeline_plugins.components.collections.uniform_api.v2_0_0 import (
     UniformAPIComponent,
+    UniformAPIService,
 )
 
 # Mock settings patcher for API request timeout
@@ -101,6 +103,46 @@ class MockAPIResponse:
         import jmespath
 
         return jmespath.search(path, self.json_resp)
+
+
+class MockSpanData:
+    def __init__(self, inputs):
+        self.inputs = inputs
+
+    def get_one_of_inputs(self, key, default=None):
+        return self.inputs.get(key, default)
+
+
+class TestUniformAPISpanAttributes(TestCase):
+    def test_get_span_attributes_includes_http_method_and_api_meta(self):
+        """API 插件 Span 属性包含 HTTP 方法和可检索的 API 元信息"""
+        service = UniformAPIService()
+        service.id = "node_1"
+        data = MockSpanData(
+            {
+                "uniform_api_plugin_url": "http://example.com/api",
+                "uniform_api_plugin_method": "GET",
+                "uniform_api_plugin_api_meta": {
+                    "id": "sops_api_001",
+                    "name": "流程执行",
+                    "meta_url": "http://example.com/meta",
+                    "api_key": "sops_execute",
+                    "category": {"id": "cat_1", "name": "标准运维"},
+                },
+            }
+        )
+        parent_data = MockSpanData(TEST_PARENT_DATA)
+
+        attributes = service._get_span_attributes(data, parent_data)
+
+        self.assertEqual(attributes["url"], "http://example.com/api")
+        self.assertEqual(attributes["http_method"], "GET")
+        self.assertNotIn("method", attributes)
+        self.assertEqual(attributes["api_id"], "sops_api_001")
+        self.assertEqual(attributes["api_name"], "流程执行")
+        self.assertEqual(attributes["api_key"], "sops_execute")
+        self.assertEqual(attributes["api_category_id"], "cat_1")
+        self.assertEqual(attributes["api_category_name"], "标准运维")
 
 
 CLIENT_API_SPACE_CONFIG = {

--- a/tests/plugins/components/collections/uniform_api_test/test_v3_0_0.py
+++ b/tests/plugins/components/collections/uniform_api_test/test_v3_0_0.py
@@ -9,6 +9,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
@@ -22,6 +23,7 @@ from pipeline.component_framework.test import (
 
 from bkflow.pipeline_plugins.components.collections.uniform_api.v3_0_0 import (
     UniformAPIComponent,
+    UniformAPIService,
 )
 
 # Mock settings patcher for API request timeout
@@ -108,6 +110,46 @@ class MockAPIResponse:
             self.resp.text = "plain text response"
         else:
             self.resp.text = str(json_resp)
+
+
+class MockSpanData:
+    def __init__(self, inputs):
+        self.inputs = inputs
+
+    def get_one_of_inputs(self, key, default=None):
+        return self.inputs.get(key, default)
+
+
+class TestUniformAPISpanAttributes(TestCase):
+    def test_get_span_attributes_includes_http_method_and_api_meta(self):
+        """API 插件 Span 属性包含 HTTP 方法和可检索的 API 元信息"""
+        service = UniformAPIService()
+        service.id = "node_1"
+        data = MockSpanData(
+            {
+                "uniform_api_plugin_url": "http://example.com/api",
+                "uniform_api_plugin_method": "POST",
+                "uniform_api_plugin_api_meta": {
+                    "id": "sops_api_001",
+                    "name": "流程执行",
+                    "meta_url": "http://example.com/meta",
+                    "api_key": "sops_execute",
+                    "category": {"id": "cat_1", "name": "标准运维"},
+                },
+            }
+        )
+        parent_data = MockSpanData(TEST_PARENT_DATA)
+
+        attributes = service._get_span_attributes(data, parent_data)
+
+        self.assertEqual(attributes["url"], "http://example.com/api")
+        self.assertEqual(attributes["http_method"], "POST")
+        self.assertNotIn("method", attributes)
+        self.assertEqual(attributes["api_id"], "sops_api_001")
+        self.assertEqual(attributes["api_name"], "流程执行")
+        self.assertEqual(attributes["api_key"], "sops_execute")
+        self.assertEqual(attributes["api_category_id"], "cat_1")
+        self.assertEqual(attributes["api_category_name"], "标准运维")
 
 
 # 标准响应模式 - 成功场景


### PR DESCRIPTION
## 变更内容

- 为 uniform_api 插件 span 增加 API 元信息属性：`api_id`、`api_name`、`api_key`、`api_category_id`、`api_category_name`。
- 将 API 插件请求方法从 `method` 调整为 `http_method`，避免覆盖统一 trace 前缀后的 `bkflow.plugin.method`。
- 在 web pipeline 格式化阶段把 `component.api_meta` 注入为隐藏输入，供插件执行/调度 span 读取，并在请求下发前移除该内部字段。
- 调整 `plugin_method_span` 的属性写入顺序，确保 `bkflow.plugin.method` 始终表示插件生命周期方法（如 `execute` / `schedule`）。

## 验证

- `.venv/bin/pytest -o addopts='' tests/engine/utils/test_trace.py tests/plugins/components/collections/uniform_api_test/test_v2_0_0.py tests/plugins/components/collections/uniform_api_test/test_v3_0_0.py tests/interface/pipeline_web/parser/format/test_format_web_data_to_pipeline.py`：35 passed, 782 warnings
- `black --check`：9 files unchanged
- `flake8`：0
- `git diff --check`：通过