### PR TITLE
fix(task): 优化执行数据内存异常提示

### DIFF
--- a/bkflow/task/apps.py
+++ b/bkflow/task/apps.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 TencentBlueKing is pleased to support the open source community by making
 蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
@@ -27,6 +26,7 @@ class TaskConfig(AppConfig):
     def ready(self):
         from bkflow.constants import RecordType  # noqa
         from bkflow.contrib.operation_record import OPERATION_RECORDER  # noqa
+        from bkflow.task.engine_patches import patch_service_activity_handler
         from bkflow.task.operation_record import (  # noqa
             TaskNodeOperationRecorder,
             TaskOperationRecorder,
@@ -35,5 +35,6 @@ class TaskConfig(AppConfig):
             bamboo_engine_eri_post_set_state_handler,
         )
 
+        patch_service_activity_handler()
         OPERATION_RECORDER.register(RecordType.task.name, TaskOperationRecorder)
         OPERATION_RECORDER.register(RecordType.task_node.name, TaskNodeOperationRecorder)

--- a/bkflow/task/engine_patches.py
+++ b/bkflow/task/engine_patches.py
@@ -1,0 +1,127 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
+Copyright (C) 2024 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+
+to the current version of the project delivered to anyone in the future.
+"""
+
+import logging
+from functools import wraps
+
+from bamboo_engine import states
+from bamboo_engine.eri import ExecutionData
+from bamboo_engine.handler import ExecuteResult
+from bamboo_engine.handlers.service_activity import ServiceActivityHandler
+
+logger = logging.getLogger(__name__)
+
+PATCHED_ATTR = "_bkflow_memory_error_handler_patched"
+
+MEMORY_ERROR_EX_DATA = "".join(
+    [
+        "节点执行数据保存失败，可能是节点输入/输出数据过大导致 worker 内存不足。",
+        "请检查上游节点输出和当前节点渲染后的输入，避免在流程变量中传递大对象。",
+    ]
+)
+
+
+def build_memory_error_ex_data(exc: MemoryError) -> str:
+    """构造节点详情中展示的内存异常提示。"""
+
+    return "{} 异常类型: {}。".format(MEMORY_ERROR_EX_DATA, exc.__class__.__name__)
+
+
+def fail_service_activity_on_memory_error(
+    handler,
+    process_info,
+    loop: int,
+    inner_loop: int,
+    version: str,
+    recover_point,
+    exc: MemoryError,
+) -> ExecuteResult:
+    """将 ServiceActivity 的内存异常转换为节点失败结果。"""
+
+    logger.error(
+        "root_pipeline[%s] node(%s) service activity failed by memory error",
+        process_info.root_pipeline_id,
+        handler.node.id,
+        exc_info=(exc.__class__, exc, exc.__traceback__),
+    )
+
+    ex_data = build_memory_error_ex_data(exc)
+    handler.runtime.node_execute_fail(process_info.root_pipeline_id, handler.node.id)
+    handler.runtime.set_state(
+        node_id=handler.node.id,
+        version=version,
+        to_state=states.FAILED,
+        set_archive_time=True,
+        ignore_boring_set=recover_point is not None,
+    )
+    handler.runtime.set_execution_data(
+        node_id=handler.node.id,
+        data=ExecutionData(
+            inputs={},
+            outputs={
+                "ex_data": ex_data,
+                "_result": False,
+                "_loop": loop,
+                "_inner_loop": inner_loop,
+            },
+        ),
+    )
+
+    return ExecuteResult(
+        should_sleep=True,
+        schedule_ready=False,
+        schedule_type=None,
+        schedule_after=-1,
+        dispatch_processes=[],
+        next_node_id=None,
+    )
+
+
+def patch_service_activity_handler():
+    """为 bamboo-engine ServiceActivity 执行阶段补充 MemoryError 兜底处理。"""
+
+    if getattr(ServiceActivityHandler.execute, PATCHED_ATTR, False):
+        return
+
+    original_execute = ServiceActivityHandler.execute
+
+    @wraps(original_execute)
+    def execute_with_memory_error_handler(
+        self,
+        process_info,
+        loop,
+        inner_loop,
+        version,
+        recover_point=None,
+    ):
+        try:
+            return original_execute(self, process_info, loop, inner_loop, version, recover_point)
+        except MemoryError as exc:
+            return fail_service_activity_on_memory_error(
+                handler=self,
+                process_info=process_info,
+                loop=loop,
+                inner_loop=inner_loop,
+                version=version,
+                recover_point=recover_point,
+                exc=exc,
+            )
+
+    setattr(execute_with_memory_error_handler, PATCHED_ATTR, True)
+    ServiceActivityHandler.execute = execute_with_memory_error_handler

--- a/tests/engine/task/test_engine_patches.py
+++ b/tests/engine/task/test_engine_patches.py
@@ -1,0 +1,110 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
+Copyright (C) 2024 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+
+to the current version of the project delivered to anyone in the future.
+"""
+
+from types import SimpleNamespace
+
+from bamboo_engine import states
+from bamboo_engine.eri import ExecutionData
+from bamboo_engine.handler import ExecuteResult
+from bamboo_engine.handlers.service_activity import ServiceActivityHandler
+
+from bkflow.task.engine_patches import (
+    fail_service_activity_on_memory_error,
+    patch_service_activity_handler,
+)
+
+
+class DummyRuntime:
+    def __init__(self):
+        self.execute_fail_calls = []
+        self.state_calls = []
+        self.execution_data_calls = []
+
+    def node_execute_fail(self, root_pipeline_id, node_id):
+        self.execute_fail_calls.append((root_pipeline_id, node_id))
+
+    def set_state(self, **kwargs):
+        self.state_calls.append(kwargs)
+
+    def set_execution_data(self, **kwargs):
+        self.execution_data_calls.append(kwargs)
+
+
+def test_fail_service_activity_on_memory_error_records_compact_failure_data():
+    runtime = DummyRuntime()
+    handler = SimpleNamespace(runtime=runtime, node=SimpleNamespace(id="node-1"))
+    process_info = SimpleNamespace(root_pipeline_id="root-1")
+
+    result = fail_service_activity_on_memory_error(
+        handler=handler,
+        process_info=process_info,
+        loop=1,
+        inner_loop=2,
+        version="version-1",
+        recover_point=None,
+        exc=MemoryError("worker memory exhausted"),
+    )
+
+    assert isinstance(result, ExecuteResult)
+    assert result.should_sleep is True
+    assert result.schedule_ready is False
+    assert result.next_node_id is None
+    assert runtime.execute_fail_calls == [("root-1", "node-1")]
+    assert runtime.state_calls == [
+        {
+            "node_id": "node-1",
+            "version": "version-1",
+            "to_state": states.FAILED,
+            "set_archive_time": True,
+            "ignore_boring_set": False,
+        }
+    ]
+
+    execution_data = runtime.execution_data_calls[0]["data"]
+    assert isinstance(execution_data, ExecutionData)
+    assert execution_data.inputs == {}
+    assert execution_data.outputs["_result"] is False
+    assert execution_data.outputs["_loop"] == 1
+    assert execution_data.outputs["_inner_loop"] == 2
+    assert "执行数据保存失败" in execution_data.outputs["ex_data"]
+    assert "节点输入/输出数据过大" in execution_data.outputs["ex_data"]
+    assert "MemoryError" in execution_data.outputs["ex_data"]
+
+
+def test_patch_service_activity_handler_converts_memory_error(monkeypatch):
+    def raise_memory_error(self, process_info, loop, inner_loop, version, recover_point=None):
+        raise MemoryError("too large")
+
+    runtime = DummyRuntime()
+    handler = SimpleNamespace(runtime=runtime, node=SimpleNamespace(id="node-1"))
+    process_info = SimpleNamespace(root_pipeline_id="root-1")
+
+    monkeypatch.setattr(ServiceActivityHandler, "execute", raise_memory_error)
+    patch_service_activity_handler()
+
+    result = ServiceActivityHandler.execute(
+        handler,
+        process_info=process_info,
+        loop=1,
+        inner_loop=1,
+        version="version-1",
+    )
+
+    assert result.schedule_ready is False
+    assert runtime.state_calls[0]["to_state"] == states.FAILED


### PR DESCRIPTION
## 变更说明

- 在 `TaskConfig.ready()` 中为 bamboo-engine `ServiceActivityHandler.execute` 增加幂等 MemoryError 兜底包装。
- 当 ServiceActivity 执行阶段保存执行数据等流程触发 Python `MemoryError` 时，将节点置为 `FAILED`，并写入紧凑 `ex_data`，提示输入/输出数据过大或 worker 内存不足。
- 新增单测覆盖节点失败状态、紧凑执行数据以及 handler 包装逻辑。

## 验证

- `bash -lc 'export $(cat tests/engine.env | xargs); /Users/dengyh/Projects/bk-flow/.venv/bin/pytest tests/engine/task/test_engine_patches.py -q --no-cov'`
- `git commit` pre-commit hooks: black / isort / flake8 / pyupgrade passed

## 关联

- TAPD: https://tapd.woa.com/70120217/bugtrace/bugs/view/1070120217157931386