### PR TITLE
fix(template): 增加 Mako 模板根标识符白名单防止 SSTI --story=134798877

### DIFF
--- a/app_desc.yaml
+++ b/app_desc.yaml
@@ -1,5 +1,5 @@
 spec_version: 2
-app_version: "1.11.10"
+app_version: "1.11.11"
 app:
   region: default
   bk_app_code: &APP_CODE bk_flow_engine

--- a/config/default.py
+++ b/config/default.py
@@ -204,6 +204,28 @@ BambooSettings.MAKO_SANDBOX_IMPORT_MODULES = MAKO_SANDBOX_IMPORT_MODULES
 # 支持 mako 表达式在 dict/list/tuple 情况下嵌套索引
 BambooSettings.ENABLE_RENDER_OBJ_BY_MAKO_STRING = True
 
+# Mako 模板根标识符白名单（详见 bamboo_engine.utils.mako_safety）：
+#   - off     -> 关闭白名单，回退到历史 deny-list（兼容旧用法）
+#   - warn    -> 仅打日志不拦截（灰度阶段使用，线上灰度若干天确认无误伤再切 enforce）
+#   - enforce -> 命中即按 ForbiddenMakoTemplateException 风格 inert 掉模板片段
+# 通过 ``BKFLOW_MAKO_WHITELIST_MODE`` 环境变量覆盖（默认 enforce）。
+MAKO_TEMPLATE_NAME_WHITELIST_MODE = env.BKFLOW_MAKO_WHITELIST_MODE
+if MAKO_TEMPLATE_NAME_WHITELIST_MODE not in {"off", "warn", "enforce"}:
+    raise ValueError(
+        "invalid BKFLOW_MAKO_WHITELIST_MODE: %r (must be one of 'off' / 'warn' / 'enforce')"
+        % MAKO_TEMPLATE_NAME_WHITELIST_MODE
+    )
+
+# 渲染期注入到 Mako context 的特殊根名（不会出现在 user-defined context keys 里）：
+# - ``_system``：``TaskContext`` / ``SystemObject``，承载 ``executor / task_id /
+#   task_start_time / task_name`` 等。详见 ``bkflow/utils/context.py``。
+# - ``_loop`` / ``_inner_loop``：循环节点的迭代序号，详见
+#   ``docs/apidoc/zh/sdk_get_task_node_detail.md``。
+MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = frozenset({"_system", "_loop", "_inner_loop"})
+
+BambooSettings.MAKO_TEMPLATE_NAME_WHITELIST_MODE = MAKO_TEMPLATE_NAME_WHITELIST_MODE
+BambooSettings.MAKO_TEMPLATE_NAME_EXTRA_WHITELIST = MAKO_TEMPLATE_NAME_EXTRA_WHITELIST
+
 # 所有环境的日志级别可以在这里配置
 # LOG_LEVEL = 'INFO'
 

--- a/env.py
+++ b/env.py
@@ -180,6 +180,13 @@ PIPELINE_RERUN_MAX_TIMES = int(os.getenv("PIPELINE_RERUN_MAX_TIMES", 100))
 PIPELINE_LOOP_OUTPUTS_INNER_KEY = os.getenv("PIPELINE_LOOP_OUTPUTS_INNER_KEY", "outputs")
 BAMBOO_DJANGO_ERI_NODE_RERUN_LIMIT = int(os.getenv("BAMBOO_DJANGO_ERI_NODE_RERUN_LIMIT", 100))
 
+# Mako 模板根标识符白名单：
+#   - "off"     -> 兼容历史行为（仅依赖 deny-list / shield words）
+#   - "warn"    -> 仅记录违规日志，不阻断渲染（线上灰度用）
+#   - "enforce" -> 命中即拦截，渲染结果保持原样回显
+# 通过 ``BKFLOW_MAKO_WHITELIST_MODE`` 环境变量覆盖，默认 ``enforce``。
+BKFLOW_MAKO_WHITELIST_MODE = os.getenv("BKFLOW_MAKO_WHITELIST_MODE", "enforce")
+
 # 模板最大递归次数
 TEMPLATE_MAX_RECURSIVE_NUMBER = int(os.getenv("TEMPLATE_MAX_RECURSIVE_NUMBER", 10))
 REQUEST_RETRY_NUMBER = int(os.getenv("REQUEST_RETRY_NUMBER", 3))

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ bk-notice-sdk==1.3.0
 
 # engine service
 boto3==1.26.133
-bamboo-pipeline==3.29.7
+bamboo-pipeline==3.29.8
 pydantic==1.10.6
 django-extensions==3.2.1
 


### PR DESCRIPTION
新增 MAKO_TEMPLATE_NAME_WHITELIST_MODE 配置（off/warn/enforce，默认 enforce） 与 MAKO_TEMPLATE_NAME_EXTRA_WHITELIST 配置（默认包含 _system / _loop / _inner_loop），并绑定到 BambooSettings，启用 bamboo-engine 侧的根标识符 白名单 + 危险 attr 链路拦截。

修复风险：
1. ${self.module.cache.util.os.popen("cmd").read()} 通过 Mako 内部命名空间 reach 到 os 模块。
2. ${os.path.os.popen("cmd").read()}（os.path 内部 import os）以及 ${datetime.sys.modules["os"].popen("cmd").read()} 等通过白名单根名 反向引用 os/sys 触达进程原语的攻击面。
3. ${context._kwargs / context._with_template} 等 Mako Context 半私有通道。

灰度建议：
线上先把 BKFLOW_MAKO_WHITELIST_MODE=warn 跑若干天，按日志确认无业务误伤， 再切 enforce。回滚直接将该环境变量改回 off 即可（不需要发版）。

依赖侧需先升级 bamboo-pipeline 到带 ``WhitelistNameVisitor`` 的版本，否则该 配置对运行时无效（仅设置 BambooSettings 属性，不影响其它流程）。