### PR TITLE
chore(deps): 升级 bamboo-pipeline 至 3.29.9

### DIFF
--- a/app_desc.yaml
+++ b/app_desc.yaml
@@ -1,5 +1,5 @@
 spec_version: 2
-app_version: "1.11.11"
+app_version: "1.11.12"
 app:
   region: default
   bk_app_code: &APP_CODE bk_flow_engine

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ bk-notice-sdk==1.3.0
 
 # engine service
 boto3==1.26.133
-bamboo-pipeline==3.29.8
+bamboo-pipeline==3.29.9
 pydantic==1.10.6
 django-extensions==3.2.1
 


### PR DESCRIPTION
## 变更说明

- 将 `bamboo-pipeline` 从 `3.29.8` 升级到 `3.29.9`
- 将 `app_desc.yaml` 版本号从 `1.11.11` 更新到 `1.11.12`

## 安全修复确认

`bamboo-pipeline 3.29.9` 主要补齐 Mako 安全加固：

- 默认 `MAKO_SANDBOX_SHIELD_WORDS` 不再为空兜底，覆盖 `getattr`、`format`、`eval`、`exec`、`open`、`__import__` 等可用于 SSTI 链路的内建入口
- 阻断 `.format` / `.format_map`、dunder subscript key、恶意 filter callable / tag-level filter 等绕过路径
- package metadata 依赖 `bamboo-engine>=2.11.3,<3.0.0`

## 验证

- `python3 -m pip index versions bamboo-pipeline` 确认 `3.29.9` 已可见
- `python3 -m pip download --no-deps bamboo-pipeline==3.29.9` 成功
- `python3 -m pip download --no-deps bamboo-engine==2.11.3` 成功
- 独立 venv 安装 `bamboo-pipeline==3.29.9` 后执行 Mako 安全 smoke：关键 payload 被拦截或原样回显，正常 `%` 格式化模板仍可渲染
- `python -m pip check` 通过
- `git diff --check` 通过
