### PR TITLE
fix(api_plugin_demo): 按环境生成演示插件路径

### DIFF
--- a/bkflow/api_plugin_demo/plugins.py
+++ b/bkflow/api_plugin_demo/plugins.py
@@ -19,6 +19,20 @@ to the current version of the project delivered to anyone in the future.
 from django.conf import settings
 
 
+def _get_api_plugin_demo_stage():
+    """
+    获取 API 插件 demo 所属网关环境
+    """
+    return (getattr(settings, "BK_APIGW_STAGE_NAME", None) or getattr(settings, "ENVIRONMENT", "stage")).strip("/")
+
+
+def _build_api_plugin_demo_path(path):
+    """
+    构建 API 插件 demo 路径
+    """
+    return f"/{_get_api_plugin_demo_stage()}/api_plugin_demo/{path.lstrip('/')}"
+
+
 def _build_api_url(request, path):
     """
     构建API URL
@@ -62,7 +76,7 @@ def get_api_list(limit, offset, scope_type, scope_value, category, request=None)
     :return: API列表数据
     """
     # 定义所有可用的API
-    base_path = "/stage/api_plugin_demo/detail_meta/"
+    base_path = _build_api_plugin_demo_path("detail_meta/")
     all_apis = [
         {
             "id": "get_user_info",
@@ -134,7 +148,7 @@ def get_api_detail(api_id, request=None):
             "id": "get_user_info",
             "name": "获取用户信息",
             "version": "v3.0.0",  # 指定使用的uniform_api插件版本
-            "url": _build_api_url(request, "/stage/api_plugin_demo/execute/get_user_info/"),
+            "url": _build_api_url(request, _build_api_plugin_demo_path("execute/get_user_info/")),
             "methods": ["GET"],
             "inputs": [
                 {
@@ -182,7 +196,7 @@ def get_api_detail(api_id, request=None):
             "id": "create_task",
             "name": "创建任务",
             "version": "v3.0.0",  # 指定使用的uniform_api插件版本
-            "url": _build_api_url(request, "/stage/api_plugin_demo/execute/create_task/"),
+            "url": _build_api_url(request, _build_api_plugin_demo_path("execute/create_task/")),
             "methods": ["POST"],
             "inputs": [
                 {
@@ -252,7 +266,7 @@ def get_api_detail(api_id, request=None):
             "id": "process_data",
             "name": "处理数据",
             "version": "v2.0.0",  # 指定使用的uniform_api插件版本（示例：使用v2.0.0版本）
-            "url": _build_api_url(request, "/stage/api_plugin_demo/execute/process_data/"),
+            "url": _build_api_url(request, _build_api_plugin_demo_path("execute/process_data/")),
             "methods": ["POST"],
             "inputs": [
                 {
@@ -333,7 +347,7 @@ def get_api_detail(api_id, request=None):
             "id": "api_with_credential",
             "name": "使用自定义凭证的API",
             "version": "v3.0.0",  # 必须使用v3.0.0版本才支持credential_key
-            "url": _build_api_url(request, "/stage/api_plugin_demo/execute/api_with_credential/"),
+            "url": _build_api_url(request, _build_api_plugin_demo_path("execute/api_with_credential/")),
             "methods": ["POST"],
             "credential_key": "custom_app_credential",  # 声明使用 custom_app_credential 凭证
             "inputs": [

--- a/tests/interface/api_plugin_demo/test_plugins.py
+++ b/tests/interface/api_plugin_demo/test_plugins.py
@@ -1,0 +1,45 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
+Copyright (C) 2024 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+
+to the current version of the project delivered to anyone in the future.
+"""
+from types import SimpleNamespace
+
+from bkflow.api_plugin_demo import plugins
+
+
+class TestApiPluginDemoPath:
+    """测试 API 插件 demo 路径生成"""
+
+    def test_builds_urls_with_current_apigw_stage(self, monkeypatch):
+        """API 插件 demo URL 使用当前网关环境"""
+        monkeypatch.setattr(
+            plugins,
+            "settings",
+            SimpleNamespace(
+                BK_API_URL_TMPL="http://{api_name}.example.com",
+                BK_APIGW_NAME="bkflow",
+                BK_APIGW_STAGE_NAME="prod",
+            ),
+        )
+
+        api_list = plugins.get_api_list(limit=10, offset=0, scope_type="", scope_value="", category="")
+        api_detail = plugins.get_api_detail("get_user_info")
+
+        assert api_list["apis"][0]["meta_url"] == (
+            "http://bkflow.example.com/prod/api_plugin_demo/detail_meta/?api_id=get_user_info"
+        )
+        assert api_detail["url"] == "http://bkflow.example.com/prod/api_plugin_demo/execute/get_user_info/"


### PR DESCRIPTION
## 变更

- API 插件 demo 的 meta_url 和执行 url 不再写死 `/stage`。
- 统一使用 `BK_APIGW_STAGE_NAME` 生成路径，缺省时回退到 `ENVIRONMENT`。
- 新增单测覆盖 prod 网关环境下的 URL 生成。

## 影响

- stag 环境继续生成 `/stage/api_plugin_demo/...`。
- prod 等其他环境会生成对应网关环境路径，例如 `/prod/api_plugin_demo/...`。

## 验证

- `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYENV_VERSION=3.6.15 /Users/dengyh/.pyenv/versions/3.6.15/bin/python -m pytest -o addopts='' tests/interface/api_plugin_demo/test_plugins.py -q`
- `PYENV_VERSION=3.6.15 /Users/dengyh/.pyenv/versions/3.6.15/bin/python -m py_compile bkflow/api_plugin_demo/plugins.py tests/interface/api_plugin_demo/test_plugins.py`
- `git diff --cached --check`