### PR TITLE
fix(plugin): 修复开放插件 v4 版本与来源持久化

### DIFF
--- a/bkflow/pipeline_plugins/query/uniform_api/utils.py
+++ b/bkflow/pipeline_plugins/query/uniform_api/utils.py
@@ -138,6 +138,27 @@ class UniformAPIClient(ApigwClientMixin, HttpRequestMixin):
     UNIFORM_API_META_RESPONSE_DATA_SCHEMA = {
         "type": "object",
         "required": ["id", "name", "url", "methods", "inputs"],
+        "anyOf": [
+            {
+                "not": {
+                    "anyOf": [
+                        {"required": ["plugin_source"]},
+                        {"required": ["plugin_code"]},
+                        {"required": ["plugin_version"]},
+                        {"required": ["wrapper_version"]},
+                    ]
+                }
+            },
+            {
+                "required": [
+                    "plugin_source",
+                    "plugin_code",
+                    "plugin_version",
+                    "wrapper_version",
+                    "outputs",
+                ]
+            },
+        ],
         "properties": {
             "id": {"type": "string"},
             "name": {"type": "string"},
@@ -167,6 +188,13 @@ class UniformAPIClient(ApigwClientMixin, HttpRequestMixin):
                         "options": {"type": "array"},
                         "form_type": {"type": "string"},
                     },
+                },
+            },
+            "outputs": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["name", "key"],
                 },
             },
             "polling": {

--- a/bkflow/plugin/services/open_plugin_catalog.py
+++ b/bkflow/plugin/services/open_plugin_catalog.py
@@ -31,16 +31,24 @@ from bkflow.space.models import Credential, SpaceConfig
 class OpenPluginCatalogService:
     @classmethod
     def sync_space_plugins(cls, space_id, source_key=None, username="admin"):
-        synced_sources = []
-        for current_source_key, api_entry in cls._get_sources(space_id=space_id, source_key=source_key).items():
+        source_plugins = {}
+        for api_key, api_entry in cls._get_sources(space_id=space_id, source_key=source_key).items():
+            current_source_key = cls._effective_source_key(api_key=api_key, api_entry=api_entry)
             api_list = cls._fetch_api_list(
                 space_id=space_id,
                 api_entry=api_entry,
                 username=username,
             )
-            cls._refresh_catalog_index(space_id=space_id, source_key=current_source_key, api_list=api_list)
-            synced_sources.append(current_source_key)
-        return synced_sources
+            plugins_by_id = source_plugins.setdefault(current_source_key, {})
+            plugins_by_id.update({api_item["id"]: api_item for api_item in api_list})
+
+        for current_source_key, plugins_by_id in source_plugins.items():
+            cls._refresh_catalog_index(
+                space_id=space_id,
+                source_key=current_source_key,
+                api_list=list(plugins_by_id.values()),
+            )
+        return list(source_plugins.keys())
 
     @classmethod
     def list_space_plugins(cls, space_id, source_key=None):
@@ -135,9 +143,20 @@ class OpenPluginCatalogService:
         config = UniformAPIConfigHandler(uniform_api_config).handle()
         sources = config.api
         if source_key:
-            entry = sources.get(source_key)
-            return {source_key: entry} if entry else {}
+            return {
+                api_key: api_entry
+                for api_key, api_entry in sources.items()
+                if cls._effective_source_key(api_key=api_key, api_entry=api_entry) == source_key
+            }
         return sources
+
+    @staticmethod
+    def _effective_source_key(api_key, api_entry):
+        if isinstance(api_entry, dict):
+            source_key = api_entry.get("source_key")
+        else:
+            source_key = getattr(api_entry, "source_key", None)
+        return source_key if isinstance(source_key, str) and source_key else api_key
 
     @classmethod
     def iter_configured_sources(cls):
@@ -147,7 +166,11 @@ class OpenPluginCatalogService:
                 continue
 
             config = UniformAPIConfigHandler(space_config.json_value).handle()
-            for source_key in config.api.keys():
+            source_keys = {
+                cls._effective_source_key(api_key=api_key, api_entry=api_entry)
+                for api_key, api_entry in config.api.items()
+            }
+            for source_key in sorted(source_keys):
                 yield space_config.space_id, source_key
 
     @classmethod

--- a/bkflow/plugin/services/open_plugin_catalog.py
+++ b/bkflow/plugin/services/open_plugin_catalog.py
@@ -169,7 +169,14 @@ class OpenPluginCatalogService:
             headers=headers,
             username=username,
         )
-        return list_result.json_resp.get("data", {}).get("apis", [])
+        if not list_result.result:
+            raise ValueError("开放插件目录请求失败: {}".format(list_result.message))
+        if not isinstance(list_result.json_resp, dict):
+            raise ValueError("开放插件目录响应不是合法 JSON")
+
+        response_data = list_result.json_resp.get("data")
+        client.validate_response_data(response_data, client.UNIFORM_API_LIST_RESPONSE_DATA_SCHEMA)
+        return response_data["apis"]
 
     @classmethod
     def _refresh_catalog_index(cls, space_id, source_key, api_list):

--- a/bkflow/plugin/services/open_plugin_snapshot.py
+++ b/bkflow/plugin/services/open_plugin_snapshot.py
@@ -200,7 +200,7 @@ class OpenPluginSnapshotService:
             plugin_version = (
                 cls._extract_data_value(data, "uniform_api_plugin_version") or api_meta.get("plugin_version") or ""
             )
-            source_key = api_meta.get("source_key")
+            source_key = cls._extract_data_value(data, "uniform_api_plugin_source_key") or api_meta.get("source_key")
             wrapper_version = component.get("version", "")
 
             if not plugin_id:

--- a/bkflow/space/configs.py
+++ b/bkflow/space/configs.py
@@ -283,6 +283,7 @@ class UniformApiConfig(BaseSpaceConfig):
                 "meta_apis": "{meta_apis url}",
                 "api_categories": "{api_categories url}",
                 "display_name": "{display_name}",
+                "source_key": "{open plugin execution source key}",
                 "headers": {"X-Custom-Header": "${_system.operator}"},
             }
         }
@@ -451,6 +452,7 @@ class ApiModel(BaseModel):
     meta_apis: str
     api_categories: str
     display_name: str
+    source_key: Optional[str] = None
     headers: Optional[dict] = None
 
     def get(self, field_name, default=None):

--- a/docs/guide/space_config.md
+++ b/docs/guide/space_config.md
@@ -80,6 +80,7 @@
             "meta_apis": "{meta_apis url}",
             "api_categories": "{api_categories url}",
             "display_name": "{display_name}",
+            "source_key": "{open plugin execution source key}"
         }
     }
 }
@@ -91,6 +92,9 @@
 | meta_apis url      | 	string	 | 获取API接口元数据列表的url |
 | api_categories url | 	string	 | 获取API接口分类列表的url  |
 | display_name	      | string	  | API插件的展示名称       |
+| source_key         | string    | 可选，开放插件的准入与执行来源；不配置时使用 api_key |
+
+每个 `api_key` 会生成一个独立的顶层 API 插件入口。多个入口可以使用不同的目录 URL（包括固定查询参数），同时配置相同的 `source_key`，从而共享同一套来源准入、插件开关与执行配置。
 **说明：** API插件具体开发可参考：[API插件开发](api_plugin.md)
 
 **功能表现：** 
@@ -100,7 +104,8 @@
     "api_key": {
       "meta_apis": "https://xxx.com/xxx/uniform_api_list/",
       "display_name": "API插件",
-      "api_categories": "https://xxx.com/xxx/uniform_api_category_list/"
+      "api_categories": "https://xxx.com/xxx/uniform_api_category_list/",
+      "source_key": "api_key"
     }
   }
 }
@@ -206,5 +211,4 @@ vertical:
 }
 ```
 ![hide display plugin](../pics/only_show_display.png)
-
 

--- a/docs/specs/2026-06-26-sops-open-plugin-full-capability-design.md
+++ b/docs/specs/2026-06-26-sops-open-plugin-full-capability-design.md
@@ -71,6 +71,8 @@
 
 未授权空间**连该来源目录都看不到**：`list_space_plugins`、schema 服务、目录同步全部要求存在有效 grant。
 
+展示配置与执行来源分层：`uniform_api.api` 的每个 `api_key` 对应流程编辑器中的一个顶层 API 插件入口；配置项可用可选 `source_key` 指向真实的准入与执行来源，未配置时回退到 `api_key`。因此标准运维内置插件和第三方插件可用两个 `api_key` 分开展示，并通过目录 URL 的固定 `plugin_source` 参数分别过滤，同时共享 `source_key=sops`。目录同步按有效 `source_key` 聚合后一次性刷新，避免两个入口互相把对方插件标记为下架。
+
 ### 4.2 第 2 层（空间级，已有）：per-plugin 治理
 
 沿用 `SpaceOpenPluginAvailability`（新来源默认关）+ per-plugin 开关 + 一键全开 + `disable_source`。「一键全开」仅在**已准入**空间内生效。

--- a/frontend/src/views/template/TemplateEdit/NodeConfig/NodeConfig.vue
+++ b/frontend/src/views/template/TemplateEdit/NodeConfig/NodeConfig.vue
@@ -652,12 +652,11 @@
               version: this.basicInfo.version,
             });
             if (!resp.result) return;
-            // basicInfo.version是业务版本，用于版本下拉框
-            const apiVersion = resp.data.version || 'v2.0.0';
-            // 使用meta API返回的version加载统一api基础配置
-            await this.loadAtomConfig({ atom: plugin, version: apiVersion, space_id: this.spaceId });
+            // component.version 保存 uniform_api 包装器版本，业务版本独立保存在隐藏字段中。
+            const wrapperVersion = resp.data.wrapper_version || resp.data.version || 'v2.0.0';
+            await this.loadAtomConfig({ atom: plugin, version: wrapperVersion, space_id: this.spaceId });
             // 输出参数
-            const storeOutputs = this.pluginOutput.uniform_api[apiVersion];
+            const storeOutputs = this.pluginOutput.uniform_api[wrapperVersion] || [];
             this.uniformOutputs = resp.data.outputs || [];
             this.outputs = [...storeOutputs];
             const { url, methods, response_data_path: respDataPath, polling, callback, credential_key } = resp.data;
@@ -671,11 +670,18 @@
               polling,
               callback,
               credentialKey: credential_key,
+              wrapperVersion,
+              pluginSource: resp.data.plugin_source || this.basicInfo.pluginSource,
+              pluginCode: resp.data.plugin_code || this.basicInfo.pluginCode,
             };
+            if (resp.data.plugin_version) {
+              updateData.version = resp.data.plugin_version;
+              updateData.uniform_api_plugin_version = resp.data.plugin_version;
+            }
             // 有 meta_url_template 时已有业务版本，不覆盖为框架版本
             // 无 meta_url_template 时（旧数据）用框架版本作为 version
             if (!this.basicInfo.meta_url_template) {
-              updateData.version = apiVersion;
+              updateData.version = wrapperVersion;
             }
             this.updateBasicInfo(updateData);
             this.apiInputs = resp.data.inputs;
@@ -950,30 +956,55 @@
             credentials,
           };
           if (component.code === 'uniform_api' &&  component.api_meta) { // 新版api插件中component包含api_meta字段
-            const { id, name, api_key: apiKey, meta_url, category = {} } = component.api_meta;
+            const {
+              id,
+              name,
+              api_key: apiKey,
+              meta_url,
+              category = {},
+              source_key: savedSourceKey,
+              plugin_source: pluginSource,
+              plugin_code: pluginCode,
+              wrapper_version: savedWrapperVersion,
+            } = component.api_meta;
             const { uniform_api_plugin_method: method, uniform_api_plugin_url: realMetaUrl } = component.data;
             // 从节点数据中读取uniform_api_plugin_credential_key（如果存在）
             const credentialKey = component.data.uniform_api_plugin_credential_key?.value;
-            // 无版本信息时 component.version 是框架版本(v2.0.0)
-            const uniformApiPluginVersion = component.api_meta.versions ? component.version : "v2.0.0";
             const versions = component.api_meta.versions || [];
             const latestVersion = component.api_meta.latest_version || '';
+            const defaultVersion = component.api_meta.default_version || '';
             const metaUrlTemplate = component.api_meta.meta_url_template || '';
+            const savedPluginVersion = component.data.uniform_api_plugin_version?.value
+              || component.api_meta.plugin_version;
+            const isOpenPlugin = versions.length > 0;
+            const uniformApiPluginVersion = isOpenPlugin
+              ? savedPluginVersion || latestVersion || defaultVersion
+              : component.version || 'v2.0.0';
+            // 兼容旧版页面曾把业务版本误存到 component.version 的节点。
+            const wrapperVersion = savedWrapperVersion || (isOpenPlugin ? 'v4.0.0' : component.version || 'v2.0.0');
+            const sourceKey = savedSourceKey || (isOpenPlugin ? apiKey : '');
             Object.assign(data, {
               plugin: 'uniform_api',
               name: `${category.name}-${name}`,
+              apiPluginName: name,
               pluginId: id,
-              method: method.value,
+              method: method?.value || '',
               groupId: category.id,
               groupName: category.name,
               apiKey,
+              sourceKey,
+              pluginSource,
+              pluginCode,
+              wrapperVersion,
+              isOpenPlugin,
               metaUrl: meta_url,
-              realMetaUrl,
+              realMetaUrl: realMetaUrl?.value || realMetaUrl,
               credentialKey, // 保存credential_key到basicInfo，以便后续使用
               methodList: [],
               desc,
               versions, // V4 API插件版本列表
               latest_version: latestVersion,
+              default_version: defaultVersion,
               meta_url_template: metaUrlTemplate,
               uniform_api_plugin_version: uniformApiPluginVersion,
               version: uniformApiPluginVersion, // 已保存节点回显已选择的版本
@@ -1174,13 +1205,24 @@
           group_id: groupId,
           metaUrl,
           apiKey,
+          sourceKey,
+          pluginSource,
+          pluginCode,
+          wrapperVersion,
         } = val;
         let versionList = [];
         if (this.isThirdParty) {
           versionList = list;
         } else if (this.isApiPlugin) {
           // API插件版本列表：val.list 是字符串数组，转换为 [{version}] 格式
-          versionList = Array.isArray(list) ? list.map(item => typeof item === 'string' ? { version: item } : item) : [];
+          versionList = Array.isArray(list)
+            ? list.map((item) => {
+              if (typeof item === 'string') {
+                return { version: item };
+              }
+              return item;
+            })
+            : [];
         } else {
           versionList = this.getAtomVersions(code);
         }
@@ -1203,11 +1245,13 @@
         // 新节点默认使用 latest_version，已保存节点优先回显uniform_api_plugin_version
         let apiPluginVersion = null;
         if (this.isApiPlugin) {
-          apiPluginVersion = val.latest_version || (versionList.length > 0 ? versionList[versionList.length - 1].version : 'V2.0.0');
+          apiPluginVersion = val.latest_version
+            || val.default_version
+            || (versionList.length > 0 ? versionList[versionList.length - 1].version : 'v2.0.0');
         }
         const config = {
           plugin: code,
-          version: apiPluginVersion || (this.isApiPlugin ? 'V2.0.0' : list[list.length - 1].version),
+          version: apiPluginVersion || (this.isApiPlugin ? 'v2.0.0' : list[list.length - 1].version),
           name: this.isThirdParty ? name : `${groupName}-${name}`,
           nodeName: name,
           stageName: '',
@@ -1227,6 +1271,12 @@
             groupName,
             metaUrl,
             apiKey,
+            sourceKey,
+            pluginSource,
+            pluginCode,
+            wrapperVersion: wrapperVersion || 'v2.0.0',
+            isOpenPlugin: Boolean(wrapperVersion && pluginSource && pluginCode && versions.length),
+            apiPluginName: name,
             meta_url_template: val.meta_url_template,
             versions,
             latest_version: val.latest_version,
@@ -1741,24 +1791,36 @@
           } else {
             data = this.getNodeComponentData(plugin, version);
           }
+          let componentVersion = version;
+          if (this.isThirdParty) {
+            componentVersion = '1.0.0';
+          } else if (this.isApiPlugin) {
+            componentVersion = this.basicInfo.wrapperVersion || 'v2.0.0';
+          }
           const component = {
             code: this.isThirdParty ? 'remote_plugin' : plugin,
             data,
-            version: this.isThirdParty ? '1.0.0' : version,
+            version: componentVersion,
           };
           if (credentials) {
             component.credentials = credentials;
           }
           if (this.isApiPlugin && this.basicInfo.pluginId) { // 新版api插件中component包含pluginId字段
             // eslint-disable-next-line camelcase
-            const { pluginId, name, metaUrl, groupId, groupName, apiKey,
+            const { pluginId, name, apiPluginName, metaUrl, groupId, groupName, apiKey,
+              sourceKey, pluginSource, pluginCode, wrapperVersion,
               meta_url_template, versions, latest_version, default_version,
               uniform_api_plugin_version, desc } = this.basicInfo;
             component.api_meta = {
               id: pluginId,
-              name: name.split('-')[1],
+              name: apiPluginName || name.substring(name.indexOf('-') + 1),
               meta_url: metaUrl,
               api_key: apiKey,
+              source_key: sourceKey,
+              plugin_source: pluginSource,
+              plugin_code: pluginCode,
+              plugin_version: uniform_api_plugin_version,
+              wrapper_version: wrapperVersion,
               category: {
                 id: groupId,
                 name: groupName,
@@ -1769,8 +1831,6 @@
               default_version,
               desc,
             };
-            // eslint-disable-next-line camelcase
-            component.version = uniform_api_plugin_version || this.basicInfo.version || 'v2.0.0';
           }
           config = Object.assign({}, this.nodeConfig, {
             component,
@@ -1848,6 +1908,16 @@
             data.uniform_api_plugin_version = {
               hook: false,
               value: this.basicInfo.uniform_api_plugin_version,
+            };
+          }
+          if (this.basicInfo.isOpenPlugin) {
+            data.uniform_api_plugin_id = {
+              hook: false,
+              value: this.basicInfo.pluginId,
+            };
+            data.uniform_api_plugin_source_key = {
+              hook: false,
+              value: this.basicInfo.sourceKey,
             };
           }
         }

--- a/frontend/src/views/template/TemplateEdit/NodeConfig/SelectPanel/apiPlugin.vue
+++ b/frontend/src/views/template/TemplateEdit/NodeConfig/SelectPanel/apiPlugin.vue
@@ -103,8 +103,14 @@
       };
     },
     computed: {
+      crtApiConfig() {
+        return this.apiTabList.find(item => item.key === this.currentTab);
+      },
       crtApiKey() {
-        return this.apiTabList.find(item => item.key === this.currentTab)?.key;
+        return this.crtApiConfig?.key;
+      },
+      crtSourceKey() {
+        return this.crtApiConfig?.sourceKey || this.crtApiKey;
       },
     },
     watch: {
@@ -231,7 +237,7 @@
           group_name: category.name || categoryId,
           metaUrl: meta_url,
           apiKey: this.crtApiKey,
-          sourceKey: this.crtApiKey,
+          sourceKey: this.crtSourceKey,
           pluginSource: plugin_source,
           pluginCode: plugin_code,
           wrapperVersion: wrapper_version,

--- a/frontend/src/views/template/TemplateEdit/NodeConfig/SelectPanel/apiPlugin.vue
+++ b/frontend/src/views/template/TemplateEdit/NodeConfig/SelectPanel/apiPlugin.vue
@@ -206,24 +206,38 @@
         this.pagination.current = 1;
         this.getUniformApiList();
       },
-      formatVersion(version) {
-        if (!version) return '';
-        return version.startsWith('v') ? version : `v${version}`;
-      },
       onSelectApiPlugin(plugin) {
-        const category = this.categoryList.find(item => item.id === this.categoryActive);
-        const { id, name, default_version, latest_version, versions, meta_url_template, meta_url, description } = plugin;
+        const {
+          id,
+          name,
+          category: pluginCategory,
+          default_version,
+          latest_version,
+          versions,
+          meta_url_template,
+          meta_url,
+          description,
+          plugin_source,
+          plugin_code,
+          wrapper_version,
+        } = plugin;
+        const categoryId = pluginCategory || this.categoryActive;
+        const category = this.categoryList.find(item => item.id === categoryId) || {};
         this.$emit('select', {
           id,
           code: 'uniform_api',
           name,
-          group_id: this.categoryActive,
-          group_name: category.name,
+          group_id: categoryId,
+          group_name: category.name || categoryId,
           metaUrl: meta_url,
           apiKey: this.crtApiKey,
-          list: (versions || []).map(v => this.formatVersion(v)),
-          latest_version: this.formatVersion(latest_version),
-          default_version: this.formatVersion(default_version),
+          sourceKey: this.crtApiKey,
+          pluginSource: plugin_source,
+          pluginCode: plugin_code,
+          wrapperVersion: wrapper_version,
+          list: versions || [],
+          latest_version,
+          default_version,
           meta_url_template,
           desc: description,
         });

--- a/frontend/src/views/template/TemplateEdit/NodeConfig/SelectPanel/plugin.vue
+++ b/frontend/src/views/template/TemplateEdit/NodeConfig/SelectPanel/plugin.vue
@@ -254,6 +254,7 @@
           acc.push({
             key,
             name: value.display_name || key,
+            sourceKey: value.source_key || key,
           });
           return acc;
         }, []);

--- a/frontend/src/views/template/TemplateEdit/index.vue
+++ b/frontend/src/views/template/TemplateEdit/index.vue
@@ -1391,16 +1391,21 @@
           // api插件是否存在
           const { code, api_meta, version } = nodeConfig.component || {};
           if (code === 'uniform_api' && !this.apiExistMap[id]) {
+            // eslint-disable-next-line camelcase
+            const { uniform_api_plugin_version: savedPluginVersion } = nodeConfig.component.data || {};
+            const pluginVersion = savedPluginVersion?.value
+              || api_meta.plugin_version
+              || version;
             const resp = await this.loadUniformApiMeta({
               templateId: this.templateId,
               spaceId: this.spaceId,
               meta_url: api_meta.meta_url,
               ...this.scopeInfo,
               meta_url_template: api_meta.meta_url_template,
-              version: version,
+              version: pluginVersion,
             });
             if (resp.result) {
-              this.apiExistMap[id] = { code, version };
+              this.apiExistMap[id] = { code, version: pluginVersion };
             }
             this.isNotExistAtomOrVersion = !resp.result;
           }

--- a/tests/interface/plugin/services/test_open_plugin_catalog.py
+++ b/tests/interface/plugin/services/test_open_plugin_catalog.py
@@ -9,6 +9,70 @@ from bkflow.plugin.services.open_plugin_grant import OpenPluginGrantService
 
 @pytest.mark.django_db
 class TestOpenPluginCatalogService:
+    @patch.object(OpenPluginCatalogService, "_refresh_catalog_index")
+    @patch.object(OpenPluginCatalogService, "_fetch_api_list")
+    @patch.object(OpenPluginCatalogService, "_get_sources")
+    def test_sync_space_plugins_aggregates_api_entries_with_same_source_key(
+        self, mock_get_sources, mock_fetch_api_list, mock_refresh_catalog_index
+    ):
+        """测试两个展示配置映射到同一来源时，只聚合刷新一次目录。"""
+        builtin_entry = MagicMock(source_key="sops")
+        third_party_entry = MagicMock(source_key="sops")
+        builtin_plugin = {"id": "builtin__job_execute_task"}
+        third_party_plugin = {"id": "danny-test-plugin"}
+        mock_get_sources.return_value = {
+            "sops_builtin": builtin_entry,
+            "sops_third_party": third_party_entry,
+        }
+        mock_fetch_api_list.side_effect = [[builtin_plugin], [third_party_plugin]]
+
+        synced_sources = OpenPluginCatalogService.sync_space_plugins(space_id=1)
+
+        assert synced_sources == ["sops"]
+        mock_refresh_catalog_index.assert_called_once_with(
+            space_id=1,
+            source_key="sops",
+            api_list=[builtin_plugin, third_party_plugin],
+        )
+
+    @patch("bkflow.plugin.services.open_plugin_catalog.SpaceConfig")
+    @patch("bkflow.plugin.services.open_plugin_catalog.UniformAPIConfigHandler")
+    def test_get_sources_filters_by_effective_source_key(self, mock_handler, mock_sc):
+        """测试同步指定来源时可选中映射到该来源的全部展示配置。"""
+        mock_sc.get_config.return_value = {"api": {}}
+        builtin_entry = MagicMock(source_key="sops")
+        third_party_entry = MagicMock(source_key="sops")
+        mock_model = MagicMock()
+        mock_model.api = {
+            "sops_builtin": builtin_entry,
+            "sops_third_party": third_party_entry,
+        }
+        mock_handler.return_value.handle.return_value = mock_model
+
+        sources = OpenPluginCatalogService._get_sources(space_id=1, source_key="sops")
+
+        assert sources == {
+            "sops_builtin": builtin_entry,
+            "sops_third_party": third_party_entry,
+        }
+
+    @patch("bkflow.plugin.services.open_plugin_catalog.SpaceConfig")
+    @patch("bkflow.plugin.services.open_plugin_catalog.UniformAPIConfigHandler")
+    def test_iter_configured_sources_deduplicates_effective_source_key(self, mock_handler, mock_sc):
+        """测试平台准入初始化按执行来源去重，而不是按展示配置授权。"""
+        space_config = MagicMock(space_id=1, json_value={"api": {}})
+        mock_sc.objects.filter.return_value.only.return_value.iterator.return_value = [space_config]
+        mock_model = MagicMock()
+        mock_model.api = {
+            "sops_builtin": MagicMock(source_key="sops"),
+            "sops_third_party": MagicMock(source_key="sops"),
+        }
+        mock_handler.return_value.handle.return_value = mock_model
+
+        configured_sources = list(OpenPluginCatalogService.iter_configured_sources())
+
+        assert configured_sources == [(1, "sops")]
+
     def test_ungranted_space_sees_no_source(self):
         """测试未准入空间看不到对应来源目录"""
         OpenPluginCatalogIndex.objects.create(

--- a/tests/interface/plugin/services/test_open_plugin_catalog.py
+++ b/tests/interface/plugin/services/test_open_plugin_catalog.py
@@ -96,6 +96,7 @@ class TestOpenPluginCatalogService:
 
         mock_client = MagicMock()
         list_resp = MagicMock()
+        list_resp.result = True
         list_resp.json_resp = {
             "data": {
                 "apis": [
@@ -172,6 +173,7 @@ class TestOpenPluginCatalogService:
 
         mock_client = MagicMock()
         list_resp = MagicMock()
+        list_resp.result = True
         list_resp.json_resp = {"data": {"apis": []}}
         mock_client.request.return_value = list_resp
         mock_client_cls.return_value = mock_client
@@ -185,3 +187,43 @@ class TestOpenPluginCatalogService:
 
         assert index.status == OpenPluginCatalogIndex.Status.UNAVAILABLE
         assert availability.enabled is True
+
+    @patch("bkflow.plugin.services.open_plugin_catalog.Credential")
+    @patch("bkflow.plugin.services.open_plugin_catalog.UniformAPIClient")
+    @patch("bkflow.plugin.services.open_plugin_catalog.SpaceConfig")
+    def test_fetch_api_list_raises_clear_error_when_remote_request_fails(self, mock_sc, mock_client_cls, mock_cred):
+        """测试目录来源请求失败时抛出可定位的错误，而不是继续解析空响应。"""
+        mock_sc.get_config.return_value = "test_cred"
+        mock_cred_obj = MagicMock()
+        mock_cred_obj.content = {"bk_app_code": "app", "bk_app_secret": "secret"}
+        mock_cred.objects.filter.return_value.first.return_value = mock_cred_obj
+
+        list_resp = MagicMock(result=False, message="gateway unavailable", json_resp=None)
+        mock_client_cls.return_value.request.return_value = list_resp
+
+        with pytest.raises(ValueError, match="开放插件目录请求失败.*gateway unavailable"):
+            OpenPluginCatalogService._fetch_api_list(
+                space_id=1,
+                api_entry=MagicMock(meta_apis="http://example.com/meta_apis"),
+                username="admin",
+            )
+
+    @patch("bkflow.plugin.services.open_plugin_catalog.Credential")
+    @patch("bkflow.plugin.services.open_plugin_catalog.UniformAPIClient")
+    @patch("bkflow.plugin.services.open_plugin_catalog.SpaceConfig")
+    def test_fetch_api_list_raises_clear_error_for_malformed_response(self, mock_sc, mock_client_cls, mock_cred):
+        """测试目录来源成功但响应体为空时抛出明确错误。"""
+        mock_sc.get_config.return_value = "test_cred"
+        mock_cred_obj = MagicMock()
+        mock_cred_obj.content = {"bk_app_code": "app", "bk_app_secret": "secret"}
+        mock_cred.objects.filter.return_value.first.return_value = mock_cred_obj
+
+        list_resp = MagicMock(result=True, message="", json_resp=None)
+        mock_client_cls.return_value.request.return_value = list_resp
+
+        with pytest.raises(ValueError, match="开放插件目录响应不是合法 JSON"):
+            OpenPluginCatalogService._fetch_api_list(
+                space_id=1,
+                api_entry=MagicMock(meta_apis="http://example.com/meta_apis"),
+                username="admin",
+            )

--- a/tests/interface/plugin/services/test_open_plugin_snapshot.py
+++ b/tests/interface/plugin/services/test_open_plugin_snapshot.py
@@ -126,6 +126,25 @@ def test_validate_passes_when_source_granted():
     OpenPluginSnapshotService.validate_pipeline_tree(space_id=1, pipeline_tree=build_open_plugin_pipeline_tree())
 
 
+def test_collect_plugin_references_reads_source_key_from_runtime_hidden_field(monkeypatch):
+    monkeypatch.setattr(OpenPluginSnapshotService, "_get_catalog_entry", lambda **kwargs: None)
+    pipeline_tree = build_open_plugin_pipeline_tree()
+    component = pipeline_tree["activities"]["node1"]["component"]
+    component["version"] = "v4.0.0"
+    component["api_meta"] = {}
+    component["data"]["uniform_api_plugin_source_key"] = {"value": "sops"}
+
+    references = OpenPluginSnapshotService.collect_plugin_references(
+        space_id=1,
+        pipeline_tree=pipeline_tree,
+        include_unmatched=True,
+    )
+
+    assert references[0]["source_key"] == "sops"
+    assert references[0]["plugin_version"] == "1.2.0"
+    assert references[0]["wrapper_version"] == "v4.0.0"
+
+
 @pytest.mark.django_db
 def test_validate_rejects_when_plugin_version_not_in_catalog_versions():
     """开放插件已准入且已开启时，仍要拒绝已从目录版本列表移除的业务版本。"""

--- a/tests/interface/space/test_space_config.py
+++ b/tests/interface/space/test_space_config.py
@@ -426,6 +426,7 @@ class TestSpaceConfigHandler:
                     "meta_apis": "http://api.apigw.example.com",
                     "api_categories": "http://api.apigw.example.com",
                     "display_name": "Test API",
+                    "source_key": "sops",
                 }
             }
         }
@@ -434,6 +435,7 @@ class TestSpaceConfigHandler:
         assert isinstance(model, SchemaV2Model)
         assert "test_api" in model.api
         assert model.api["test_api"].display_name == "Test API"
+        assert model.api["test_api"].source_key == "sops"
 
         # Test V1 schema (legacy)
         v1_config = {

--- a/tests/plugins/uniform_api/test_uniform_api_client.py
+++ b/tests/plugins/uniform_api/test_uniform_api_client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 TencentBlueKing is pleased to support the open source community by making
 蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
@@ -21,11 +20,13 @@ import pytest
 from django.conf import settings
 
 from bkflow.exceptions import APIRequestError, ValidationError
+from bkflow.pipeline_plugins.query.uniform_api.uniform_api import (
+    UniformAPIMetaSerializer,
+)
 from bkflow.pipeline_plugins.query.uniform_api.utils import (
     UniformAPIClient,
     resolve_meta_url,
 )
-from bkflow.pipeline_plugins.query.uniform_api.uniform_api import UniformAPIMetaSerializer
 from bkflow.utils.api_client import HttpRequestResult
 
 
@@ -135,6 +136,7 @@ class TestUniformAPIClient:
             "url": "https://bk-sops.example/open-plugin-runs",
             "methods": ["POST"],
             "inputs": [],
+            "outputs": [],
             "polling": {
                 "url": "https://bk-sops.example/open-plugin-runs/status",
                 "task_tag_key": "open_plugin_run_id",
@@ -146,6 +148,45 @@ class TestUniformAPIClient:
 
         with pytest.raises(ValidationError):
             self.client.validate_response_data(invalid_instance, self.client.UNIFORM_API_META_RESPONSE_DATA_SCHEMA)
+
+    def test_validate_v4_detail_meta_requires_complete_contract(self):
+        invalid_instance = {
+            "id": "open_plugin_001",
+            "name": "JOB 执行作业",
+            "plugin_source": "builtin",
+            "plugin_code": "job_execute_task",
+            "plugin_version": "1.2.0",
+            "wrapper_version": "v4.0.0",
+            "url": "https://bk-sops.example/open-plugin-runs",
+            "methods": ["POST"],
+            "inputs": [],
+        }
+
+        with pytest.raises(ValidationError):
+            self.client.validate_response_data(invalid_instance, self.client.UNIFORM_API_META_RESPONSE_DATA_SCHEMA)
+
+    def test_validate_complete_v4_detail_meta_contract(self):
+        valid_instance = {
+            "id": "open_plugin_001",
+            "name": "JOB 执行作业",
+            "plugin_source": "builtin",
+            "plugin_code": "job_execute_task",
+            "plugin_version": "legacy",
+            "wrapper_version": "v4.0.0",
+            "url": "https://bk-sops.example/open-plugin-runs",
+            "methods": ["POST"],
+            "inputs": [],
+            "outputs": [{"name": "作业实例 ID", "key": "job_instance_id"}],
+            "polling": {
+                "url": "https://bk-sops.example/open-plugin-runs/status",
+                "task_tag_key": "open_plugin_run_id",
+                "success_tag": {"key": "status", "value": "SUCCEEDED", "data_key": "data.outputs"},
+                "fail_tag": {"key": "status", "value": "FAILED", "msg_key": "data.error_message"},
+                "running_tag": {"key": "status", "value": "RUNNING"},
+            },
+        }
+
+        self.client.validate_response_data(valid_instance, self.client.UNIFORM_API_META_RESPONSE_DATA_SCHEMA)
 
     def test_resolve_meta_url_returns_plain_meta_url_first(self):
         assert (


### PR DESCRIPTION
## 变更内容

- 目录同步在远端失败或响应畸形时返回明确错误，并复用 uniform_api schema 校验
- 编辑器严格区分 `component.version` 的 wrapper 版本与子插件业务版本，不再给业务版本自动添加 `v`
- 保存 `uniform_api_plugin_id` / `uniform_api_plugin_source_key`，兼容并可修复此前误存业务版本的 v4 节点
- `uniform_api` 配置新增可选 `source_key`，允许多个展示 `api_key` 共享同一个准入与执行来源
- 同源展示配置的目录按 `source_key` 聚合后一次性刷新，避免两个入口互相将插件标记下架
- 流程编辑器按 `api_key` 展示与查询，按真实 `source_key` 保存和执行

## 验证

- `pytest tests/interface/space/test_space_config.py tests/interface/plugin/services/test_open_plugin_catalog.py tests/interface/plugin/services/test_open_plugin_grant.py tests/interface/plugin/services/test_open_plugin_snapshot.py -v --no-cov`
- 49 tests passed
- 修改 Vue 文件 ESLint、pre-commit 通过
- 完整 webpack 在本地因已安装依赖缺少 `@blueking/bkflow-canvas-editor-vue2` 未完成，报错位于未改动的 `TaskOperation.vue`

--story=133649781