### PR TITLE
fix(open-plugin): 修复异步调度与目录分页问题

### DIFF
--- a/bkflow/interface/urls.py
+++ b/bkflow/interface/urls.py
@@ -16,6 +16,7 @@ We undertake not to change the open source license (MIT license) applicable
 
 to the current version of the project delivered to anyone in the future.
 """
+
 from django.conf.urls import url
 from django.urls import include
 
@@ -25,6 +26,7 @@ from .views import (
     home,
     is_admin_or_current_space_superuser,
     is_admin_or_space_superuser,
+    open_plugin_callback,
     user_exit,
 )
 
@@ -34,6 +36,10 @@ urlpatterns = [
     url(r"^is_admin_user/$", is_admin_or_space_superuser),
     url(r"^is_current_space_admin/$", is_admin_or_current_space_superuser),
     url(r"^callback/(?P<token>.+)/$", callback),
+    url(
+        r"^open_plugin_callback/space/(?P<space_id>\d+)/task/(?P<task_id>\d+)/node/(?P<node_id>[^/]+)/$",
+        open_plugin_callback,
+    ),
     url(r"^itsm_approve/$", itsm_approve),
     url(r"^openapi/", include("bkflow.interface.openapi.urls")),
     url(r"", include("bkflow.interface.task.urls")),

--- a/bkflow/interface/urls.py
+++ b/bkflow/interface/urls.py
@@ -26,7 +26,6 @@ from .views import (
     home,
     is_admin_or_current_space_superuser,
     is_admin_or_space_superuser,
-    open_plugin_callback,
     user_exit,
 )
 
@@ -36,10 +35,6 @@ urlpatterns = [
     url(r"^is_admin_user/$", is_admin_or_space_superuser),
     url(r"^is_current_space_admin/$", is_admin_or_current_space_superuser),
     url(r"^callback/(?P<token>.+)/$", callback),
-    url(
-        r"^open_plugin_callback/space/(?P<space_id>\d+)/task/(?P<task_id>\d+)/node/(?P<node_id>[^/]+)/$",
-        open_plugin_callback,
-    ),
     url(r"^itsm_approve/$", itsm_approve),
     url(r"^openapi/", include("bkflow.interface.openapi.urls")),
     url(r"", include("bkflow.interface.task.urls")),

--- a/bkflow/interface/views.py
+++ b/bkflow/interface/views.py
@@ -16,6 +16,7 @@ We undertake not to change the open source license (MIT license) applicable
 
 to the current version of the project delivered to anyone in the future.
 """
+
 import json
 import logging
 import traceback
@@ -119,6 +120,21 @@ def callback(request, token):
         logger.error(message)
         return JsonResponse({"result": False, "message": message}, status=400)
 
+    callback_token = request.META.get(OPEN_PLUGIN_CALLBACK_TOKEN_META_KEY, "")
+    is_open_plugin_callback = callback_token or (
+        isinstance(callback_data, dict) and callback_data.get("open_plugin_run_id")
+    )
+    if is_open_plugin_callback:
+        if (
+            not isinstance(callback_data, dict)
+            or not callback_data.get("open_plugin_run_id")
+            or not callback_data.get("status")
+        ):
+            return JsonResponse({"result": False, "message": "invalid callback payload"}, status=400)
+        if not callback_token:
+            return JsonResponse({"result": False, "message": "missing callback token"}, status=400)
+        callback_data["_callback_token"] = callback_token
+
     client = TaskComponentClient(space_id=space_id)
 
     data = {"version": node_version, "data": callback_data}
@@ -132,50 +148,5 @@ def callback(request, token):
     logger.info(
         "[callback] resp, space_id={}, task_id={}, node_id={}, resp={}".format(space_id, task_id, node_id, resp)
     )
-    return JsonResponse(resp)
-
-
-@login_exempt
-@csrf_exempt
-@require_POST
-def open_plugin_callback(request, space_id, task_id, node_id):
-    """Forward a token-authenticated open-plugin callback to the task module."""
-
-    try:
-        callback_data = json.loads(request.body)
-    except Exception:
-        return JsonResponse({"result": False, "message": "invalid callback payload"}, status=400)
-
-    if (
-        not isinstance(callback_data, dict)
-        or not callback_data.get("open_plugin_run_id")
-        or not callback_data.get("status")
-    ):
-        return JsonResponse({"result": False, "message": "invalid callback payload"}, status=400)
-
-    callback_token = request.META.get(OPEN_PLUGIN_CALLBACK_TOKEN_META_KEY, "")
-    if not callback_token:
-        return JsonResponse({"result": False, "message": "missing callback token"}, status=400)
-
-    callback_data["_callback_token"] = callback_token
-    client = TaskComponentClient(space_id=space_id)
-    try:
-        resp = client.node_operate(
-            task_id=int(task_id),
-            node_id=node_id,
-            operation="callback",
-            data={"operator": "system", "data": callback_data},
-        )
-    except Exception:
-        message = _("开放插件回调失败: 请求任务模块失败. {msg}").format(msg=traceback.format_exc())
-        logger.error(message)
-        return JsonResponse({"result": False, "message": message}, status=502)
-
-    logger.info(
-        "[open_plugin_callback] space_id=%s, task_id=%s, node_id=%s, resp=%s",
-        space_id,
-        task_id,
-        node_id,
-        resp,
-    )
-    return JsonResponse(resp, status=200 if resp.get("result") else 400)
+    status = 400 if is_open_plugin_callback and not resp.get("result") else 200
+    return JsonResponse(resp, status=status)

--- a/bkflow/interface/views.py
+++ b/bkflow/interface/views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 TencentBlueKing is pleased to support the open source community by making
 蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
@@ -37,6 +36,7 @@ from django.views.decorators.http import require_GET, require_POST
 from bkflow.contrib.api.collections.task import TaskComponentClient
 from bkflow.space.configs import SuperusersConfig
 from bkflow.space.models import Space, SpaceConfig
+from bkflow.task.open_plugin_callback import OPEN_PLUGIN_CALLBACK_TOKEN_META_KEY
 
 logger = logging.getLogger("root")
 
@@ -115,9 +115,7 @@ def callback(request, token):
     try:
         callback_data = json.loads(request.body)
     except Exception:
-        message = _("节点回调失败: 无效的请求, 请重试. 如持续失败可联系管理员处理. {msg} | api callback").format(
-            msg=traceback.format_exc()
-        )
+        message = _("节点回调失败: 无效的请求, 请重试. 如持续失败可联系管理员处理. {msg} | api callback").format(msg=traceback.format_exc())
         logger.error(message)
         return JsonResponse({"result": False, "message": message}, status=400)
 
@@ -135,3 +133,49 @@ def callback(request, token):
         "[callback] resp, space_id={}, task_id={}, node_id={}, resp={}".format(space_id, task_id, node_id, resp)
     )
     return JsonResponse(resp)
+
+
+@login_exempt
+@csrf_exempt
+@require_POST
+def open_plugin_callback(request, space_id, task_id, node_id):
+    """Forward a token-authenticated open-plugin callback to the task module."""
+
+    try:
+        callback_data = json.loads(request.body)
+    except Exception:
+        return JsonResponse({"result": False, "message": "invalid callback payload"}, status=400)
+
+    if (
+        not isinstance(callback_data, dict)
+        or not callback_data.get("open_plugin_run_id")
+        or not callback_data.get("status")
+    ):
+        return JsonResponse({"result": False, "message": "invalid callback payload"}, status=400)
+
+    callback_token = request.META.get(OPEN_PLUGIN_CALLBACK_TOKEN_META_KEY, "")
+    if not callback_token:
+        return JsonResponse({"result": False, "message": "missing callback token"}, status=400)
+
+    callback_data["_callback_token"] = callback_token
+    client = TaskComponentClient(space_id=space_id)
+    try:
+        resp = client.node_operate(
+            task_id=int(task_id),
+            node_id=node_id,
+            operation="callback",
+            data={"operator": "system", "data": callback_data},
+        )
+    except Exception:
+        message = _("开放插件回调失败: 请求任务模块失败. {msg}").format(msg=traceback.format_exc())
+        logger.error(message)
+        return JsonResponse({"result": False, "message": message}, status=502)
+
+    logger.info(
+        "[open_plugin_callback] space_id=%s, task_id=%s, node_id=%s, resp=%s",
+        space_id,
+        task_id,
+        node_id,
+        resp,
+    )
+    return JsonResponse(resp, status=200 if resp.get("result") else 400)

--- a/bkflow/pipeline_plugins/components/collections/uniform_api/v4_0_0.py
+++ b/bkflow/pipeline_plugins/components/collections/uniform_api/v4_0_0.py
@@ -71,6 +71,7 @@ def build_open_plugin_cancel_url(trigger_url, open_plugin_run_id):
 
 
 class UniformAPIService(V3UniformAPIService):
+    OPEN_PLUGIN_POLLING_INTERVAL = 10
     OPEN_PLUGIN_WAITING_CALLBACK = "WAITING_CALLBACK"
     OPEN_PLUGIN_RUNNING_STATES = {"CREATED", "RUNNING"}
     OPEN_PLUGIN_SUCCESS_STATES = {"SUCCEEDED"}
@@ -119,6 +120,57 @@ class UniformAPIService(V3UniformAPIService):
             defaults={**defaults, "open_plugin_run_id": open_plugin_run_id},
         )
 
+    def plugin_schedule(self, data, parent_data, callback_data=None):
+        if not self._is_open_plugin_request(data):
+            return super().plugin_schedule(data, parent_data, callback_data)
+
+        need_polling = data.get_one_of_outputs("need_polling", False)
+        need_callback = data.get_one_of_outputs("need_callback", False)
+        if callback_data is not None and need_callback:
+            return self._dispatch_schedule_callback(data, parent_data, callback_data)
+        if need_polling:
+            return self._dispatch_schedule_polling(data, parent_data, callback_data)
+        if need_callback:
+            return self._dispatch_schedule_callback(data, parent_data, callback_data)
+        return self._dispatch_schedule_trigger(data, parent_data, callback_data)
+
+    def _handle_open_plugin_status(self, data, status_data, polling, log_prefix):
+        """Apply a v4 run status while preserving polling as callback fallback."""
+
+        run_status = status_data.get("status")
+        if run_status in self.OPEN_PLUGIN_SUCCESS_STATES:
+            data.outputs.data = status_data.get("outputs", {})
+            data.set_outputs("need_polling", False)
+            data.set_outputs("need_callback", False)
+            self.finish_schedule()
+            return True
+
+        if run_status in self.OPEN_PLUGIN_FAILED_STATES:
+            data.set_outputs("need_polling", False)
+            data.set_outputs("need_callback", False)
+            data.outputs.ex_data = status_data.get("error_message") or f"{log_prefix} get fail status: {status_data}"
+            return False
+
+        if run_status == self.OPEN_PLUGIN_WAITING_CALLBACK:
+            data.set_outputs("need_callback", True)
+            if polling:
+                self.interval.init_interval = self.OPEN_PLUGIN_POLLING_INTERVAL
+                data.set_outputs("need_polling", True)
+            else:
+                self.interval = None
+                data.set_outputs("need_polling", False)
+            return True
+
+        if run_status in self.OPEN_PLUGIN_RUNNING_STATES and polling:
+            self.interval.init_interval = self.OPEN_PLUGIN_POLLING_INTERVAL
+            data.set_outputs("need_polling", True)
+            return True
+
+        message = f"{log_prefix} get status fail: {status_data}"
+        self.logger.error(message)
+        data.outputs.ex_data = message
+        return False
+
     def _dispatch_schedule_trigger(self, data, parent_data, callback_data=None):
         if not self._is_open_plugin_request(data):
             return super()._dispatch_schedule_trigger(data, parent_data, callback_data)
@@ -127,7 +179,7 @@ class UniformAPIService(V3UniformAPIService):
         api_data = copy.deepcopy(data.inputs)
         url = api_data.pop("uniform_api_plugin_url")
         polling = api_data.pop("uniform_api_plugin_polling", None)
-        callback = api_data.pop("uniform_api_plugin_callback", None)
+        api_data.pop("uniform_api_plugin_callback", None)
         method = api_data.pop("uniform_api_plugin_method")
         credential_key = api_data.pop("uniform_api_plugin_credential_key", None)
         plugin_id = api_data.pop("uniform_api_plugin_id")
@@ -268,20 +320,12 @@ class UniformAPIService(V3UniformAPIService):
         )
         data.outputs.trigger_data = {"open_plugin_run_id": open_plugin_run_id}
 
-        run_status = resp_data.get("status")
-        if callback and run_status == self.OPEN_PLUGIN_WAITING_CALLBACK:
-            self.interval = None
-            data.set_outputs("need_callback", True)
-            data.set_outputs("need_polling", False)
-            return True
-        if polling:
-            self.interval.init_interval = 10
-            data.set_outputs("need_polling", True)
-            return True
-
-        data.outputs.data = resp_data
-        self.finish_schedule()
-        return True
+        return self._handle_open_plugin_status(
+            data=data,
+            status_data=resp_data,
+            polling=polling,
+            log_prefix="[uniform_api]",
+        )
 
     def _dispatch_schedule_polling(self, data, parent_data, callback_data=None):
         if not self._is_open_plugin_request(data):
@@ -368,28 +412,25 @@ class UniformAPIService(V3UniformAPIService):
             return False
 
         status_data = request_result.json_resp.get("data", {})
-        run_status = status_data.get("status")
-        if run_status == self.OPEN_PLUGIN_WAITING_CALLBACK:
-            self.interval = None
-            data.set_outputs("need_polling", False)
-            data.set_outputs("need_callback", True)
-            return True
-        if run_status in self.OPEN_PLUGIN_SUCCESS_STATES:
-            data.outputs.data = status_data.get("outputs", {})
-            self.finish_schedule()
-            return True
-        if run_status in self.OPEN_PLUGIN_FAILED_STATES:
-            data.outputs.ex_data = (
-                status_data.get("error_message") or f"[uniform_api polling] get fail status: {status_data}"
-            )
-            return False
-        if run_status in self.OPEN_PLUGIN_RUNNING_STATES:
+        return self._handle_open_plugin_status(
+            data=data,
+            status_data=status_data,
+            polling=polling,
+            log_prefix="[uniform_api polling]",
+        )
+
+    def _dispatch_schedule_callback(self, data, parent_data, callback_data=None):
+        if not self._is_open_plugin_request(data):
+            return super()._dispatch_schedule_callback(data, parent_data, callback_data)
+        if callback_data is None:
             return True
 
-        message = f"[uniform_api polling] get status fail: {status_data}"
-        self.logger.error(message)
-        data.outputs.ex_data = message
-        return False
+        return self._handle_open_plugin_status(
+            data=data,
+            status_data=callback_data,
+            polling=data.get_one_of_inputs("uniform_api_plugin_polling", None),
+            log_prefix="[uniform_api callback]",
+        )
 
 
 class UniformAPIComponent(Component):

--- a/bkflow/pipeline_plugins/components/collections/uniform_api/v4_0_0.py
+++ b/bkflow/pipeline_plugins/components/collections/uniform_api/v4_0_0.py
@@ -26,10 +26,9 @@ from pipeline.component_framework.component import Component
 
 from bkflow.contrib.api.collections.interface import InterfaceModuleClient
 from bkflow.pipeline_plugins.query.uniform_api.utils import UniformAPIClient
-from bkflow.pipeline_plugins.utils import convert_dict_value
+from bkflow.pipeline_plugins.utils import convert_dict_value, get_node_callback_url
 from bkflow.space.configs import UniformAPIConfigHandler
 from bkflow.task.open_plugin_callback import (
-    build_open_plugin_callback_url,
     build_open_plugin_client_request_id,
     callback_token_digest,
     issue_open_plugin_callback_token,
@@ -242,8 +241,11 @@ class UniformAPIService(V3UniformAPIService):
         client_request_id = build_open_plugin_client_request_id(
             task_id=parent_data.get_one_of_inputs("task_id"), node_id=self.id, retry_no=retry_no
         )
-        callback_url = build_open_plugin_callback_url(
-            space_id=space_id, task_id=parent_data.get_one_of_inputs("task_id"), node_id=self.id
+        callback_url = get_node_callback_url(
+            space_id=space_id,
+            task_id=parent_data.get_one_of_inputs("task_id"),
+            node_id=self.id,
+            node_version=getattr(self, "version", ""),
         )
         callback_token, expire_at = issue_open_plugin_callback_token(
             task_id=parent_data.get_one_of_inputs("task_id"),

--- a/bkflow/plugin/services/open_plugin_callback.py
+++ b/bkflow/plugin/services/open_plugin_callback.py
@@ -18,7 +18,6 @@ to the current version of the project delivered to anyone in the future.
 """
 
 from bkflow.task.open_plugin_callback import (  # noqa
-    build_open_plugin_callback_url,
     build_open_plugin_client_request_id,
     callback_token_digest,
     issue_open_plugin_callback_token,

--- a/bkflow/task/open_plugin_callback.py
+++ b/bkflow/task/open_plugin_callback.py
@@ -27,7 +27,6 @@ from django.conf import settings
 from django.utils import timezone
 
 import env
-from config.default import BKAPP_INNER_CALLBACK_ENTRY
 
 DEFAULT_CALLBACK_TOKEN_TTL = timedelta(hours=2)
 OPEN_PLUGIN_CALLBACK_TOKEN_META_KEY = "HTTP_X_CALLBACK_TOKEN"
@@ -46,11 +45,6 @@ def _get_callback_fernet():
 
 def build_open_plugin_client_request_id(task_id, node_id, retry_no=1):
     return f"task-{task_id}-node-{node_id}-attempt-{retry_no}"
-
-
-def build_open_plugin_callback_url(space_id, task_id, node_id):
-    callback_entry = BKAPP_INNER_CALLBACK_ENTRY.rstrip("/")
-    return f"{callback_entry}/open_plugin_callback/space/{space_id}/task/{task_id}/node/{node_id}/"
 
 
 def callback_token_digest(token):

--- a/bkflow/task/open_plugin_callback.py
+++ b/bkflow/task/open_plugin_callback.py
@@ -30,6 +30,7 @@ import env
 from config.default import BKAPP_INNER_CALLBACK_ENTRY
 
 DEFAULT_CALLBACK_TOKEN_TTL = timedelta(hours=2)
+OPEN_PLUGIN_CALLBACK_TOKEN_META_KEY = "HTTP_X_CALLBACK_TOKEN"
 
 
 def _get_callback_fernet():
@@ -48,7 +49,8 @@ def build_open_plugin_client_request_id(task_id, node_id, retry_no=1):
 
 
 def build_open_plugin_callback_url(space_id, task_id, node_id):
-    return f"{BKAPP_INNER_CALLBACK_ENTRY}apigw/space/{space_id}/task/{task_id}/node/{node_id}/operate_node/callback/"
+    callback_entry = BKAPP_INNER_CALLBACK_ENTRY.rstrip("/")
+    return f"{callback_entry}/open_plugin_callback/space/{space_id}/task/{task_id}/node/{node_id}/"
 
 
 def callback_token_digest(token):

--- a/docs/specs/2026-06-26-sops-open-plugin-full-capability-design.md
+++ b/docs/specs/2026-06-26-sops-open-plugin-full-capability-design.md
@@ -64,11 +64,11 @@ V4 节点不在流程保存时固化同步、轮询或回调模式，而是以 e
 - `CREATED / RUNNING` 继续轮询。
 - `WAITING_CALLBACK` 同时接受真实回调并保留轮询兜底；回调投递失败时，节点仍可通过状态查询收敛，不把当前 polling tick 切成 callback tick 后提前结束。
 
-标准运维不持有 BKFlow APIGW 应用凭证，因此 callback URL 指向 interface 模块的直连内部入口：
+标准运维不持有 BKFlow APIGW 应用凭证，因此 callback URL 复用 BKFlow 已有的节点回调入口（方案 B）：
 
-`/open_plugin_callback/space/{space_id}/task/{task_id}/node/{node_id}/`
+`/callback/{encrypted_node_token}/`
 
-入口要求 `X-Callback-Token` 请求头并把请求转发至 task 模块；engine 侧继续校验 token 签名、有效期，以及 token 与 task/node/client_request_id/open_plugin_run_id 的绑定关系。只有 engine 返回 `result=True` 时，interface 才返回 2xx，标准运维方才可把本次投递标记为成功。
+URL 中的存量 token 用于定位 `space/task/node/version`；入口收到开放插件回调后，再把 `X-Callback-Token` 运行凭证转发至 task 模块。engine 侧继续校验运行 token 的签名、有效期，以及 token 与 task/node/client_request_id/open_plugin_run_id 的绑定关系。只有 engine 返回 `result=True` 时，interface 才返回 2xx，标准运维方才可把本次投递标记为成功。普通存量节点回调不要求 `X-Callback-Token`，行为保持不变。
 
 ## 4. 两层空间准入
 

--- a/docs/specs/2026-06-26-sops-open-plugin-full-capability-design.md
+++ b/docs/specs/2026-06-26-sops-open-plugin-full-capability-design.md
@@ -54,7 +54,21 @@
 
 ### 3.2 改动位置
 
-`bkflow/pipeline_plugins/components/collections/uniform_api/v4_0_0.py` 的开放插件执行分支：在构造 execute payload 时附加 `context`。其余执行 / 轮询 / 回调逻辑不变。
+`bkflow/pipeline_plugins/components/collections/uniform_api/v4_0_0.py` 的开放插件执行分支：在构造 execute payload 时附加 `context`。
+
+### 3.3 调度模式自适应与回调入口
+
+V4 节点不在流程保存时固化同步、轮询或回调模式，而是以 execute / polling 每次返回的 `status` 决定后续动作：
+
+- `SUCCEEDED / FAILED / CANCELLED` 立即结束，不因 detail 中存在 polling 配置而额外等待一次轮询。
+- `CREATED / RUNNING` 继续轮询。
+- `WAITING_CALLBACK` 同时接受真实回调并保留轮询兜底；回调投递失败时，节点仍可通过状态查询收敛，不把当前 polling tick 切成 callback tick 后提前结束。
+
+标准运维不持有 BKFlow APIGW 应用凭证，因此 callback URL 指向 interface 模块的直连内部入口：
+
+`/open_plugin_callback/space/{space_id}/task/{task_id}/node/{node_id}/`
+
+入口要求 `X-Callback-Token` 请求头并把请求转发至 task 模块；engine 侧继续校验 token 签名、有效期，以及 token 与 task/node/client_request_id/open_plugin_run_id 的绑定关系。只有 engine 返回 `result=True` 时，interface 才返回 2xx，标准运维方才可把本次投递标记为成功。
 
 ## 4. 两层空间准入
 

--- a/frontend/src/views/template/TemplateEdit/NodeConfig/SelectPanel/apiPlugin.vue
+++ b/frontend/src/views/template/TemplateEdit/NodeConfig/SelectPanel/apiPlugin.vue
@@ -22,7 +22,9 @@
           {{ option.name }}
         </div>
       </div>
-      <div class="api-list">
+      <div
+        class="api-list"
+        @scroll="handleApiPluginScroll">
         <template v-if="apiList.length > 0">
           <div
             v-for="(plugin, index) in apiList"
@@ -128,14 +130,6 @@
         deep: true,
         immediate: true,
       },
-    },
-    mounted() {
-      const listWrapEl = this.$el.querySelector('.api-list');
-      listWrapEl.addEventListener('scroll', this.handleApiPluginScroll, false);
-    },
-    beforeDestroy() {
-      const listWrapEl = this.$el.querySelector('.api-list');
-      listWrapEl.removeEventListener('scroll', this.handleApiPluginScroll, false);
     },
     methods: {
       ...mapActions('template', [

--- a/tests/interface/test_open_plugin_callback.py
+++ b/tests/interface/test_open_plugin_callback.py
@@ -8,13 +8,21 @@ Licensed under the MIT License. See http://opensource.org/licenses/MIT.
 import json
 from unittest import mock
 
-from django.test import TestCase
+from cryptography.fernet import Fernet
+from django.conf import settings
+from django.test import TestCase, override_settings
 
 
+@override_settings(CALLBACK_KEY=Fernet.generate_key())
 class TestOpenPluginCallback(TestCase):
+    @staticmethod
+    def _callback_path(node_version="v4.0.0"):
+        token = Fernet(settings.CALLBACK_KEY).encrypt(f"10:123:node_a:{node_version}".encode()).decode("utf-8")
+        return f"/callback/{token}/"
+
     @mock.patch("bkflow.interface.views.TaskComponentClient")
     def test_callback_forwards_token_authenticated_payload_to_engine(self, mock_client_class):
-        """A valid callback is forwarded with its token intact."""
+        """方案 B 存量入口把开放插件运行 token 透传给 engine。"""
 
         mock_client = mock.Mock()
         mock_client.node_operate.return_value = {"result": True, "data": None, "message": "success"}
@@ -26,7 +34,7 @@ class TestOpenPluginCallback(TestCase):
         }
 
         response = self.client.post(
-            "/open_plugin_callback/space/10/task/123/node/node_a/",
+            self._callback_path(),
             data=json.dumps(payload),
             content_type="application/json",
             HTTP_X_CALLBACK_TOKEN="callback-token",
@@ -35,21 +43,21 @@ class TestOpenPluginCallback(TestCase):
         self.assertEqual(response.status_code, 200)
         mock_client_class.assert_called_once_with(space_id="10")
         mock_client.node_operate.assert_called_once_with(
-            task_id=123,
+            task_id="123",
             node_id="node_a",
             operation="callback",
             data={
-                "operator": "system",
+                "version": "v4.0.0",
                 "data": {**payload, "_callback_token": "callback-token"},
             },
         )
 
     @mock.patch("bkflow.interface.views.TaskComponentClient")
     def test_callback_rejects_invalid_payload_before_forwarding(self, mock_client_class):
-        """Malformed callback data is rejected before crossing module boundaries."""
+        """携带开放插件 token 的非法 payload 不进入 task 模块。"""
 
         response = self.client.post(
-            "/open_plugin_callback/space/10/task/123/node/node_a/",
+            self._callback_path(),
             data=json.dumps({"status": "SUCCEEDED"}),
             content_type="application/json",
             HTTP_X_CALLBACK_TOKEN="callback-token",
@@ -60,10 +68,10 @@ class TestOpenPluginCallback(TestCase):
 
     @mock.patch("bkflow.interface.views.TaskComponentClient")
     def test_callback_rejects_missing_token_before_forwarding(self, mock_client_class):
-        """A callback without the shared run token is rejected immediately."""
+        """开放插件回调缺少运行 token 时立即拒绝。"""
 
         response = self.client.post(
-            "/open_plugin_callback/space/10/task/123/node/node_a/",
+            self._callback_path(),
             data=json.dumps({"open_plugin_run_id": "run-001", "status": "SUCCEEDED"}),
             content_type="application/json",
         )
@@ -73,17 +81,40 @@ class TestOpenPluginCallback(TestCase):
 
     @mock.patch("bkflow.interface.views.TaskComponentClient")
     def test_callback_propagates_engine_rejection_as_bad_request(self, mock_client_class):
-        """The provider must not mark a callback delivered when the engine rejects it."""
+        """engine 拒绝开放插件回调时返回非 2xx，供提供方重试。"""
 
         mock_client = mock.Mock()
         mock_client.node_operate.return_value = {"result": False, "data": None, "message": "invalid callback token"}
         mock_client_class.return_value = mock_client
 
         response = self.client.post(
-            "/open_plugin_callback/space/10/task/123/node/node_a/",
+            self._callback_path(),
             data=json.dumps({"open_plugin_run_id": "run-001", "status": "SUCCEEDED"}),
             content_type="application/json",
             HTTP_X_CALLBACK_TOKEN="callback-token",
         )
 
         self.assertEqual(response.status_code, 400)
+
+    @mock.patch("bkflow.interface.views.TaskComponentClient")
+    def test_callback_keeps_legacy_payload_behavior(self, mock_client_class):
+        """普通存量回调不要求开放插件 token，转发结构保持不变。"""
+
+        mock_client = mock.Mock()
+        mock_client.node_operate.return_value = {"result": True, "data": None, "message": "success"}
+        mock_client_class.return_value = mock_client
+        payload = {"status": "success", "data": {"result": "done"}}
+
+        response = self.client.post(
+            self._callback_path(node_version="v3.0.0"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_client.node_operate.assert_called_once_with(
+            task_id="123",
+            node_id="node_a",
+            operation="callback",
+            data={"version": "v3.0.0", "data": payload},
+        )

--- a/tests/interface/test_open_plugin_callback.py
+++ b/tests/interface/test_open_plugin_callback.py
@@ -1,0 +1,89 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+BlueKing Flow Engine Service available.
+Copyright (C) 2024 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License. See http://opensource.org/licenses/MIT.
+"""
+
+import json
+from unittest import mock
+
+from django.test import TestCase
+
+
+class TestOpenPluginCallback(TestCase):
+    @mock.patch("bkflow.interface.views.TaskComponentClient")
+    def test_callback_forwards_token_authenticated_payload_to_engine(self, mock_client_class):
+        """A valid callback is forwarded with its token intact."""
+
+        mock_client = mock.Mock()
+        mock_client.node_operate.return_value = {"result": True, "data": None, "message": "success"}
+        mock_client_class.return_value = mock_client
+        payload = {
+            "open_plugin_run_id": "run-001",
+            "status": "SUCCEEDED",
+            "outputs": {"job_instance_id": 1001},
+        }
+
+        response = self.client.post(
+            "/open_plugin_callback/space/10/task/123/node/node_a/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            HTTP_X_CALLBACK_TOKEN="callback-token",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_client_class.assert_called_once_with(space_id="10")
+        mock_client.node_operate.assert_called_once_with(
+            task_id=123,
+            node_id="node_a",
+            operation="callback",
+            data={
+                "operator": "system",
+                "data": {**payload, "_callback_token": "callback-token"},
+            },
+        )
+
+    @mock.patch("bkflow.interface.views.TaskComponentClient")
+    def test_callback_rejects_invalid_payload_before_forwarding(self, mock_client_class):
+        """Malformed callback data is rejected before crossing module boundaries."""
+
+        response = self.client.post(
+            "/open_plugin_callback/space/10/task/123/node/node_a/",
+            data=json.dumps({"status": "SUCCEEDED"}),
+            content_type="application/json",
+            HTTP_X_CALLBACK_TOKEN="callback-token",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        mock_client_class.assert_not_called()
+
+    @mock.patch("bkflow.interface.views.TaskComponentClient")
+    def test_callback_rejects_missing_token_before_forwarding(self, mock_client_class):
+        """A callback without the shared run token is rejected immediately."""
+
+        response = self.client.post(
+            "/open_plugin_callback/space/10/task/123/node/node_a/",
+            data=json.dumps({"open_plugin_run_id": "run-001", "status": "SUCCEEDED"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        mock_client_class.assert_not_called()
+
+    @mock.patch("bkflow.interface.views.TaskComponentClient")
+    def test_callback_propagates_engine_rejection_as_bad_request(self, mock_client_class):
+        """The provider must not mark a callback delivered when the engine rejects it."""
+
+        mock_client = mock.Mock()
+        mock_client.node_operate.return_value = {"result": False, "data": None, "message": "invalid callback token"}
+        mock_client_class.return_value = mock_client
+
+        response = self.client.post(
+            "/open_plugin_callback/space/10/task/123/node/node_a/",
+            data=json.dumps({"open_plugin_run_id": "run-001", "status": "SUCCEEDED"}),
+            content_type="application/json",
+            HTTP_X_CALLBACK_TOKEN="callback-token",
+        )
+
+        self.assertEqual(response.status_code, 400)

--- a/tests/plugins/components/collections/uniform_api_test/test_v4_0_0.py
+++ b/tests/plugins/components/collections/uniform_api_test/test_v4_0_0.py
@@ -8,6 +8,7 @@ from bkflow.pipeline_plugins.components.collections.uniform_api.v4_0_0 import (
     build_open_plugin_execute_payload,
 )
 from bkflow.task.open_plugin_callback import (
+    build_open_plugin_callback_url,
     issue_open_plugin_callback_token,
     parse_open_plugin_callback_token,
 )
@@ -110,6 +111,13 @@ def test_issue_open_plugin_callback_token_round_trip():
     assert payload["expire_at"] == expire_at.isoformat()
 
 
+def test_build_open_plugin_callback_url_uses_direct_internal_endpoint(settings):
+    callback_url = build_open_plugin_callback_url(space_id=10, task_id=123, node_id="node_a")
+
+    assert callback_url.endswith("open_plugin_callback/space/10/task/123/node/node_a/")
+    assert "/apigw/" not in callback_url
+
+
 class AttrDict(dict):
     """支持属性访问的测试数据容器。"""
 
@@ -148,6 +156,72 @@ class FakeParentData:
 
     def get_one_of_inputs(self, key, default=None):
         return self.inputs.get(key, default)
+
+
+def test_open_plugin_sync_success_finishes_without_polling():
+    service = UniformAPIService()
+    data = FakeData({})
+
+    result = service._handle_open_plugin_status(
+        data=data,
+        status_data={"status": "SUCCEEDED", "outputs": {"value": "done"}},
+        polling={"url": "https://bk-sops.example/runs/status/"},
+        log_prefix="[uniform_api]",
+    )
+
+    assert result is True
+    assert service.is_schedule_finished() is True
+    assert data.outputs.data == {"value": "done"}
+    assert data.outputs.get("need_polling", False) is False
+
+
+def test_open_plugin_waiting_callback_keeps_polling_fallback():
+    service = UniformAPIService()
+    original_interval = service.interval
+    data = FakeData({})
+
+    result = service._handle_open_plugin_status(
+        data=data,
+        status_data={"status": "WAITING_CALLBACK"},
+        polling={"url": "https://bk-sops.example/runs/status/"},
+        log_prefix="[uniform_api polling]",
+    )
+
+    assert result is True
+    assert service.interval is original_interval
+    assert service.is_schedule_finished() is False
+    assert data.outputs.need_callback is True
+    assert data.outputs.need_polling is True
+
+
+def test_open_plugin_schedule_prefers_callback_data_and_otherwise_polls():
+    service = UniformAPIService()
+    data = FakeData({"uniform_api_plugin_id": "builtin__job_execute_task"})
+    data.outputs.need_callback = True
+    data.outputs.need_polling = True
+    parent_data = FakeParentData({})
+    dispatched = []
+    service._dispatch_schedule_callback = lambda *args, **kwargs: dispatched.append("callback") or True
+    service._dispatch_schedule_polling = lambda *args, **kwargs: dispatched.append("polling") or True
+
+    assert service.plugin_schedule(data, parent_data, callback_data=None) is True
+    assert service.plugin_schedule(data, parent_data, callback_data={"status": "SUCCEEDED"}) is True
+    assert dispatched == ["polling", "callback"]
+
+
+def test_open_plugin_standard_callback_finishes_with_outputs():
+    service = UniformAPIService()
+    data = FakeData({"uniform_api_plugin_id": "builtin__job_execute_task"})
+
+    result = service._dispatch_schedule_callback(
+        data,
+        FakeParentData({}),
+        callback_data={"status": "SUCCEEDED", "outputs": {"value": "callback-done"}},
+    )
+
+    assert result is True
+    assert service.is_schedule_finished() is True
+    assert data.outputs.data == {"value": "callback-done"}
 
 
 def test_open_plugin_execute_branch_passes_runtime_context(monkeypatch, settings):

--- a/tests/plugins/components/collections/uniform_api_test/test_v4_0_0.py
+++ b/tests/plugins/components/collections/uniform_api_test/test_v4_0_0.py
@@ -8,7 +8,6 @@ from bkflow.pipeline_plugins.components.collections.uniform_api.v4_0_0 import (
     build_open_plugin_execute_payload,
 )
 from bkflow.task.open_plugin_callback import (
-    build_open_plugin_callback_url,
     issue_open_plugin_callback_token,
     parse_open_plugin_callback_token,
 )
@@ -109,13 +108,6 @@ def test_issue_open_plugin_callback_token_round_trip():
     assert payload["node_version"] == "v4.0.0"
     assert payload["client_request_id"] == "task-1-node-node_a-attempt-1"
     assert payload["expire_at"] == expire_at.isoformat()
-
-
-def test_build_open_plugin_callback_url_uses_direct_internal_endpoint(settings):
-    callback_url = build_open_plugin_callback_url(space_id=10, task_id=123, node_id="node_a")
-
-    assert callback_url.endswith("open_plugin_callback/space/10/task/123/node/node_a/")
-    assert "/apigw/" not in callback_url
 
 
 class AttrDict(dict):
@@ -271,6 +263,20 @@ def test_open_plugin_execute_branch_passes_runtime_context(monkeypatch, settings
         "bkflow.pipeline_plugins.components.collections.uniform_api.v4_0_0.issue_open_plugin_callback_token",
         lambda **kwargs: ("callback-token", None),
     )
+    monkeypatch.setattr(
+        "bkflow.pipeline_plugins.components.collections.uniform_api.v4_0_0.get_node_callback_url",
+        lambda space_id, task_id, node_id, node_version="": captured.update(
+            {
+                "callback_url_args": {
+                    "space_id": space_id,
+                    "task_id": task_id,
+                    "node_id": node_id,
+                    "node_version": node_version,
+                }
+            }
+        )
+        or "https://bkflow.example/callback/encrypted-node-token/",
+    )
 
     service = UniformAPIService()
     service.id = "node_a"
@@ -311,6 +317,13 @@ def test_open_plugin_execute_branch_passes_runtime_context(monkeypatch, settings
         "task_name": "全量插件联调",
     }
     assert captured["data"]["inputs"] == {"target_ip": "127.0.0.1"}
+    assert captured["data"]["callback_url"] == "https://bkflow.example/callback/encrypted-node-token/"
+    assert captured["callback_url_args"] == {
+        "space_id": 10,
+        "task_id": 123,
+        "node_id": "node_a",
+        "node_version": "",
+    }
 
 
 def test_resolve_open_plugin_source_key_uses_saved_hidden_field_only():

--- a/tests/plugins/uniform_api/test_api_plugin_vue.py
+++ b/tests/plugins/uniform_api/test_api_plugin_vue.py
@@ -1,0 +1,28 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+BlueKing Flow Engine Service available.
+Copyright (C) 2024 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License. See http://opensource.org/licenses/MIT.
+"""
+
+from pathlib import Path
+
+
+def test_each_api_plugin_list_owns_its_scroll_handler():
+    """Every rendered source tab binds pagination to its own scroll container."""
+
+    source_path = (
+        Path(__file__).resolve().parents[3]
+        / "frontend"
+        / "src"
+        / "views"
+        / "template"
+        / "TemplateEdit"
+        / "NodeConfig"
+        / "SelectPanel"
+        / "apiPlugin.vue"
+    )
+    source = source_path.read_text(encoding="utf-8")
+
+    assert '@scroll="handleApiPluginScroll"' in source
+    assert "querySelector('.api-list')" not in source


### PR DESCRIPTION
## 变更说明

- 从最新 `develop` 创建独立集成分支，仅同步规范开发分支 `feat/sops-open-plugin-backend` 上的后续修复，未执行 rebase
- 修复开放插件异步状态处理及轮询兜底
- V4 回调复用存量方案 B `/callback/{encrypted_node_token}/`，移除新增的独立回调路由
- 存量入口仅对开放插件 payload 透传 `X-Callback-Token`，普通 V2/V3 节点回调保持原行为
- 修复 API 插件分类列表分页滚动加载
- 同步相关设计说明与回归用例

## 验证

- interface/APIGW/V3/V4 定向回归：20 passed
- engine callback token、绑定关系与幂等回归：13 passed
- 存量 callback 入口定向回归：5 passed
- pre-commit：Black、isort、Flake8、pyupgrade 全部通过
- `git diff --check`：通过