### PR TITLE
fix(open-plugin): 兼容存量 API 插件节点

### DIFF
--- a/bkflow/plugin/services/open_plugin_snapshot.py
+++ b/bkflow/plugin/services/open_plugin_snapshot.py
@@ -16,6 +16,7 @@ We undertake not to change the open source license (MIT license) applicable
 
 to the current version of the project delivered to anyone in the future.
 """
+
 from copy import deepcopy
 
 from rest_framework import serializers
@@ -29,6 +30,7 @@ class OpenPluginSnapshotService:
     REFERENCE_SNAPSHOT_KEY = "plugin_reference_snapshot"
     SCHEMA_SNAPSHOT_KEY = "plugin_schema_snapshot"
     SCHEMA_PROTOCOL_VERSION = "open_plugin_snapshot.v1"
+    OPEN_PLUGIN_WRAPPER_VERSION = "v4.0.0"
 
     @classmethod
     def get_reference_snapshot(cls, extra_info):
@@ -196,6 +198,8 @@ class OpenPluginSnapshotService:
             component = node.get("component", {})
             if component.get("code") != "uniform_api":
                 continue
+            if not cls._is_open_plugin_component(component):
+                continue
 
             data = component.get("data", {})
             api_meta = component.get("api_meta", {})
@@ -210,10 +214,6 @@ class OpenPluginSnapshotService:
                 continue
 
             catalog = cls._get_catalog_entry(space_id=space_id, plugin_id=plugin_id, source_key=source_key)
-            is_explicit_open_plugin = bool(source_key or cls._extract_data_value(data, "uniform_api_plugin_id"))
-            if catalog is None and not is_explicit_open_plugin:
-                continue
-
             if catalog and not plugin_version:
                 plugin_version = catalog.latest_version or catalog.default_version or ""
 
@@ -241,6 +241,22 @@ class OpenPluginSnapshotService:
         if include_unmatched:
             return references
         return [ref for ref in references if ref["catalog"] is not None]
+
+    @classmethod
+    def _is_open_plugin_component(cls, component):
+        """判断 uniform_api 节点是否使用开放插件 v4 协议。"""
+
+        data = component.get("data", {})
+        api_meta = component.get("api_meta", {})
+        if cls._extract_data_value(data, "uniform_api_plugin_id"):
+            return True
+
+        wrapper_version = api_meta.get("wrapper_version") or component.get("version")
+        if wrapper_version == cls.OPEN_PLUGIN_WRAPPER_VERSION:
+            return True
+
+        # 兼容早期页面曾将业务版本写入 component.version 的开放插件节点。
+        return bool(api_meta.get("versions") and api_meta.get("meta_url_template"))
 
     @staticmethod
     def _extract_data_value(data, key):

--- a/frontend/src/views/template/TemplateEdit/NodeConfig/NodeConfig.vue
+++ b/frontend/src/views/template/TemplateEdit/NodeConfig/NodeConfig.vue
@@ -1816,7 +1816,6 @@
               name: apiPluginName || name.substring(name.indexOf('-') + 1),
               meta_url: metaUrl,
               api_key: apiKey,
-              source_key: sourceKey,
               plugin_source: pluginSource,
               plugin_code: pluginCode,
               plugin_version: uniform_api_plugin_version,
@@ -1831,6 +1830,9 @@
               default_version,
               desc,
             };
+            if (this.basicInfo.isOpenPlugin) {
+              component.api_meta.source_key = sourceKey;
+            }
           }
           config = Object.assign({}, this.nodeConfig, {
             component,

--- a/tests/interface/plugin/services/test_open_plugin_snapshot.py
+++ b/tests/interface/plugin/services/test_open_plugin_snapshot.py
@@ -145,6 +145,54 @@ def test_collect_plugin_references_reads_source_key_from_runtime_hidden_field(mo
     assert references[0]["wrapper_version"] == "v4.0.0"
 
 
+def test_validate_pipeline_tree_ignores_legacy_uniform_api_with_source_key():
+    """旧版 API 插件即使携带入口 source_key，也不应进入开放插件目录校验。"""
+
+    pipeline_tree = build_open_plugin_pipeline_tree()
+    component = pipeline_tree["activities"]["node1"]["component"]
+    component["version"] = "v2.0.0"
+    component["api_meta"] = {
+        "id": "34097",
+        "name": "Tlog_玩家状态快照",
+        "source_key": "default",
+        "meta_url": "https://example.com/meta/?function_id=34097",
+    }
+    component["data"] = {
+        "uniform_api_plugin_url": {"value": "https://example.com/execute/"},
+        "uniform_api_plugin_method": {"value": "POST"},
+        "uniform_api_plugin_version": {"value": "v2.0.0"},
+    }
+    with patch.object(OpenPluginSnapshotService, "_get_catalog_entry", return_value=None) as get_catalog_entry:
+        OpenPluginSnapshotService.validate_pipeline_tree(space_id=1, pipeline_tree=pipeline_tree)
+
+    get_catalog_entry.assert_not_called()
+
+
+def test_collect_plugin_references_recognizes_legacy_saved_open_plugin_metadata(monkeypatch):
+    """早期开放插件节点即使误存了业务版本，也应继续参与开放插件校验。"""
+
+    pipeline_tree = build_open_plugin_pipeline_tree()
+    component = pipeline_tree["activities"]["node1"]["component"]
+    component["version"] = "1.2.0"
+    component["api_meta"] = {
+        "id": "open_plugin_001",
+        "source_key": "sops",
+        "versions": ["1.2.0"],
+        "meta_url_template": "https://example.com/open-plugins/open_plugin_001?version={version}",
+    }
+    component["data"].pop("uniform_api_plugin_id")
+    monkeypatch.setattr(OpenPluginSnapshotService, "_get_catalog_entry", lambda **kwargs: None)
+
+    references = OpenPluginSnapshotService.collect_plugin_references(
+        space_id=1,
+        pipeline_tree=pipeline_tree,
+        include_unmatched=True,
+    )
+
+    assert references[0]["plugin_id"] == "open_plugin_001"
+    assert references[0]["source_key"] == "sops"
+
+
 @pytest.mark.django_db
 def test_validate_rejects_when_plugin_version_not_in_catalog_versions():
     """开放插件已准入且已开启时，仍要拒绝已从目录版本列表移除的业务版本。"""


### PR DESCRIPTION
## 问题

旧 uniform_api v2/v3 节点在前端保存入口 source_key 后，被开放插件快照服务误判为 v4 开放插件，保存或建任务时报“开放插件不存在或已下线”。

## 修复

- 使用 v4 显式字段、wrapper_version 或历史版本元数据识别开放插件，不再以 source_key 单独判定
- 旧 API 插件不再持久化开放插件 source_key
- 保留早期已保存 v4 节点的识别兼容
- 增加现场同形数据 34097/v2.0.0/default 的回归测试

## 验证

- open_plugin_snapshot: 8 passed
- template views: 82 passed
- create/operate task: 8 passed
- frontend ESLint: passed
- pre-commit: passed

--story=133649781