### PR TITLE
fix(open-plugin): 修复 V4 任务详情版本解析 --story=133649781

### DIFF
--- a/frontend/src/store/modules/template.js
+++ b/frontend/src/store/modules/template.js
@@ -17,6 +17,7 @@ import validatePipeline from '@/utils/validatePipeline.js';
 import axios from 'axios';
 import i18n from '@/config/i18n/index.js';
 import { stage } from '@/components/canvas/StageCanvas/data.js';
+import { buildUniformApiMetaParams } from '@/utils/uniformApi.js';
 const ATOM_TYPE_DICT = {
   startpoint: 'EmptyStartEvent',
   endpoint: 'EmptyEndEvent',
@@ -1175,18 +1176,8 @@ const template = {
     },
     // api插件请求详情
     loadUniformApiMeta({ state }, data) {
-      const {  spaceId, meta_url, scope_type, scope_value, taskId, templateId, meta_url_template: metaUrlTemplate, version } = data;
-      const paramsData = {
-        meta_url,
-        scope_type,
-        scope_value,
-      };
-      if (metaUrlTemplate) {
-        paramsData.meta_url_template = metaUrlTemplate;
-        if (version) {
-          paramsData.version = String(version).replace(/^v/i, '');
-        }
-      }
+      const { spaceId, taskId, templateId } = data;
+      const paramsData = buildUniformApiMetaParams(data);
       if (taskId) {
         paramsData.task_id = taskId;
       } else {

--- a/frontend/src/utils/uniformApi.js
+++ b/frontend/src/utils/uniformApi.js
@@ -1,0 +1,38 @@
+const getComponentDataValue = (data, key) => {
+  const item = data[key];
+  if (item && typeof item === 'object' && Object.prototype.hasOwnProperty.call(item, 'value')) {
+    return item.value;
+  }
+  return item;
+};
+
+export const resolveUniformApiPluginVersion = (component = {}) => {
+  const data = component.data || {};
+  const apiMeta = component.api_meta || {};
+  return getComponentDataValue(data, 'uniform_api_plugin_version')
+    || getComponentDataValue(data, 'plugin_version')
+    || apiMeta.plugin_version
+    || component.version
+    || '';
+};
+
+export const buildUniformApiMetaParams = ({
+  meta_url: metaUrl,
+  meta_url_template: metaUrlTemplate,
+  version,
+  scope_type: scopeType,
+  scope_value: scopeValue,
+}) => {
+  const params = {
+    meta_url: metaUrl,
+    scope_type: scopeType,
+    scope_value: scopeValue,
+  };
+  if (metaUrlTemplate) {
+    params.meta_url_template = metaUrlTemplate;
+    if (version !== undefined && version !== null && version !== '') {
+      params.version = String(version);
+    }
+  }
+  return params;
+};

--- a/frontend/src/views/task/TaskExecute/ExecuteInfo.vue
+++ b/frontend/src/views/task/TaskExecute/ExecuteInfo.vue
@@ -255,6 +255,7 @@
   import { checkDataType, getDefaultValueFormat } from '@/utils/checkDataType.js';
   import permission from '@/mixins/permission.js';
   import { graphToJson } from '@/utils/graphJson.js';
+  import { resolveUniformApiPluginVersion } from '@/utils/uniformApi.js';
   import axios from 'axios';
   import SubflowCanvas from '../../../components/canvas/ProcessCanvas/SubflowCanvas.vue';
 
@@ -1070,7 +1071,7 @@
                 meta_url: apiMeta.meta_url,
                 ...this.scopeInfo,
                 meta_url_template: apiMeta.meta_url_template,
-                version: this.nodeActivity.component.version,
+                version: resolveUniformApiPluginVersion(this.nodeActivity.component),
               });
               if (!resp.result) return;
               // 如果meta API返回了version字段，使用它；否则使用默认值v2.0.0

--- a/frontend/src/views/task/TaskExecute/ExecuteInfo/ExecuteInfoForm.vue
+++ b/frontend/src/views/task/TaskExecute/ExecuteInfo/ExecuteInfoForm.vue
@@ -196,6 +196,7 @@
   import JsonschemaInputParams from '@/views/template/TemplateEdit/NodeConfig/JsonschemaInputParams.vue';
   import NoData from '@/components/common/base/NoData.vue';
   import jsonFormSchema from '@/utils/jsonFormSchema.js';
+  import { resolveUniformApiPluginVersion } from '@/utils/uniformApi.js';
   import SpecialPluginInputForm from '@/components/SpecialPluginInputForm/index.vue';
 
   export default {
@@ -588,7 +589,7 @@
               meta_url: apiMeta.meta_url,
               ...this.scopeInfo,
               meta_url_template: apiMeta.meta_url_template,
-              version: this.nodeActivity.component.version,
+              version: resolveUniformApiPluginVersion(this.nodeActivity.component),
             });
             if (!resp.result) return;
             // 如果meta API返回了version字段，使用它；否则使用默认值v2.0.0

--- a/frontend/src/views/task/TaskExecute/ExecuteInfoCompoment/ExecuteInfoForm.vue
+++ b/frontend/src/views/task/TaskExecute/ExecuteInfoCompoment/ExecuteInfoForm.vue
@@ -239,6 +239,7 @@
   import JsonschemaInputParams from '@/views/template/TemplateEdit/NodeConfig/JsonschemaInputParams.vue';
   import NoData from '@/components/common/base/NoData.vue';
   import jsonFormSchema from '@/utils/jsonFormSchema.js';
+  import { resolveUniformApiPluginVersion } from '@/utils/uniformApi.js';
   import SpecialPluginInputForm from '@/components/SpecialPluginInputForm/index.vue';
 
   export default {
@@ -697,7 +698,7 @@
               meta_url: apiMeta.meta_url,
               ...this.scopeInfo,
               meta_url_template: apiMeta.meta_url_template,
-              version: this.nodeActivity.component.version,
+              version: resolveUniformApiPluginVersion(this.nodeActivity.component),
             });
             if (!resp.result) return;
             // 如果meta API返回了version字段，使用它；否则使用默认值v2.0.0

--- a/frontend/src/views/task/TaskExecute/SideDrawerExecuteInfo.vue
+++ b/frontend/src/views/task/TaskExecute/SideDrawerExecuteInfo.vue
@@ -247,6 +247,7 @@
   import OptionsPanel from './ExecuteInfoCompoment/OptionsPanel.vue';
   import LoopCountSelector from './ExecuteInfoCompoment/LoopCountSelector.vue';
   import { getOrderNodeToNodeTree } from '@/utils/orderCanvasNodeToNodeTree.js';
+  import { resolveUniformApiPluginVersion } from '@/utils/uniformApi.js';
   import JumpLinkBKFlowOrExternal from '@/components/common/JumpLinkBKFlowOrExternal.vue';
   import SubStageCanvas from '../../../components/canvas/StageCanvas/SubStageCanvas.vue';
   const { CancelToken } = axios;
@@ -1259,7 +1260,7 @@
           try {
             // api插件输入输出
             if (this.pluginCode === 'uniform_api') {
-              const { api_meta: apiMeta, version } = this.nodeActivity.component || {};
+              const { api_meta: apiMeta } = this.nodeActivity.component || {};
               if (!apiMeta) return;
               // 先获取api插件配置，以获取正确的version
               const resp = await this.loadUniformApiMeta({
@@ -1268,7 +1269,7 @@
                 meta_url: apiMeta.meta_url,
                 ...this.scopeInfo,
                 meta_url_template: apiMeta.meta_url_template,
-                version,
+                version: resolveUniformApiPluginVersion(this.nodeActivity.component),
               });
               if (!resp.result) return;
               // 如果meta API返回了version字段，使用它；否则使用默认值v2.0.0

--- a/frontend/tests/uniformApi.test.mjs
+++ b/frontend/tests/uniformApi.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const source = await readFile(new URL('../src/utils/uniformApi.js', import.meta.url), 'utf8');
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString('base64')}`;
+const {
+  buildUniformApiMetaParams,
+  resolveUniformApiPluginVersion,
+} = await import(moduleUrl);
+
+test('resolveUniformApiPluginVersion uses the saved business version', () => {
+  const component = {
+    version: 'v4.0.0',
+    data: {
+      uniform_api_plugin_version: { value: 'v1.0' },
+    },
+    api_meta: {
+      plugin_version: 'legacy',
+    },
+  };
+
+  assert.equal(resolveUniformApiPluginVersion(component), 'v1.0');
+});
+
+test('resolveUniformApiPluginVersion supports metadata and legacy fallbacks', () => {
+  assert.equal(resolveUniformApiPluginVersion({
+    version: 'v4.0.0',
+    api_meta: { plugin_version: 'v2.0' },
+  }), 'v2.0');
+  assert.equal(resolveUniformApiPluginVersion({ version: 'v3.0.0' }), 'v3.0.0');
+});
+
+test('buildUniformApiMetaParams preserves opaque plugin versions', () => {
+  assert.deepEqual(buildUniformApiMetaParams({
+    meta_url: '',
+    meta_url_template: 'https://example.com/plugins/demo/?version={version}',
+    version: 'v1.0',
+    scope_type: 'biz',
+    scope_value: '2',
+  }), {
+    meta_url: '',
+    meta_url_template: 'https://example.com/plugins/demo/?version={version}',
+    version: 'v1.0',
+    scope_type: 'biz',
+    scope_value: '2',
+  });
+});


### PR DESCRIPTION
## 问题

V4 API 插件任务详情把 uniform_api 包装器版本 `v4.0.0` 当成插件业务版本请求 meta 接口，并额外移除了业务版本的 `v` 前缀，导致详情页提示插件版本不可用。

## 修复

- 从节点隐藏字段或 `api_meta.plugin_version` 读取插件业务版本，兼容旧节点回退
- 将插件版本视为不透明字符串，按目录原值传递，不再删除 `v` 前缀
- 统一现行及存量任务详情组件的版本解析

## 验证

- `node --test frontend/tests/uniformApi.test.mjs`
- 修改文件定向 ESLint 通过
- `npm run build:development` 通过（仅仓库存量 webpack warnings）