### PR TITLE
fix(open-plugin): 支持完整表单元数据渲染

### DIFF
--- a/bkflow/pipeline_plugins/query/uniform_api/utils.py
+++ b/bkflow/pipeline_plugins/query/uniform_api/utils.py
@@ -190,6 +190,14 @@ class UniformAPIClient(ApigwClientMixin, HttpRequestMixin):
                     },
                 },
             },
+            "form_schema": {
+                "type": "object",
+                "properties": {
+                    "type": {"type": "string"},
+                    "properties": {"type": "object"},
+                    "required": {"type": "array", "items": {"type": "string"}},
+                },
+            },
             "outputs": {
                 "type": "array",
                 "items": {

--- a/docs/guide/api_plugin.md
+++ b/docs/guide/api_plugin.md
@@ -201,6 +201,8 @@ sequenceDiagram
 - 基于inputs和outputs字段，动态进行表单生成
 	- 当响应包含带 `properties` 的 `form_schema` 时，BKFlow 优先按完整 schema 渲染，并保留其中的 `ui:component`、`ui:rules`、`ui:reactions` 等配置
 	- `inputs` 仍为必填兼容字段；未提供 `form_schema` 时继续按 `inputs` 生成表单
+	- 标准控件名支持 `input`、`textarea`、`password`、`codeEditor`、`select`、`radio`、`checkbox`、`switcher` 和 `table`；`code_editor` 会兼容转换为 `codeEditor`
+	- `codeEditor` 使用 BKFlow 内置 Monaco 编辑器，可通过 `props.language`、`props.height` 和 `props.showMiniMap` 配置；未知控件名会按字段类型降级，不会加载提供方 JavaScript
 	- 字段类型(type)与表单类型映射关系：
 		- string -> 输入框
 		- list -> checkbox，需要提供options字段

--- a/docs/guide/api_plugin.md
+++ b/docs/guide/api_plugin.md
@@ -126,6 +126,24 @@ sequenceDiagram
         "default": "abc"  // 可选
       }
     ],
+    "form_schema": { // 可选，完整 JSON 表单 schema；存在 properties 时优先于 inputs 渲染
+      "type": "object",
+      "properties": {
+        "xxx": {
+          "type": "string",
+          "title": "xxx",
+          "ui:component": {
+            "name": "select",
+            "props": {
+              "datasource": [
+                {"label": "A", "value": "a"},
+                {"label": "B", "value": "b"}
+              ]
+            }
+          }
+        }
+      }
+    },
     "outputs": [
       {
         "key": "xxx",
@@ -181,6 +199,8 @@ sequenceDiagram
 - `credential_key` 字段仅在使用 `uniform_api` 插件版本 `v3.0.0` 时生效
 - 用户创建任务时，可以通过 `credentials` 参数传入对应的凭证，格式参考 [create_task API 文档](../apigw/docs/zh/create_task.md)
 - 基于inputs和outputs字段，动态进行表单生成
+	- 当响应包含带 `properties` 的 `form_schema` 时，BKFlow 优先按完整 schema 渲染，并保留其中的 `ui:component`、`ui:rules`、`ui:reactions` 等配置
+	- `inputs` 仍为必填兼容字段；未提供 `form_schema` 时继续按 `inputs` 生成表单
 	- 字段类型(type)与表单类型映射关系：
 		- string -> 输入框
 		- list -> checkbox，需要提供options字段
@@ -649,4 +669,3 @@ sequenceDiagram
    - `data_key` 和 `msg_key` 都支持 jmespath 语法，可以提取嵌套字段
    - 例如：`"data.result"` 可以提取 `{"data": {"result": "value"}}` 中的 `"value"`
    - 例如：`"items[0].name"` 可以提取数组第一个元素的 name 字段
-

--- a/docs/plans/2026-07-22-open-plugin-declarative-form-controls.md
+++ b/docs/plans/2026-07-22-open-plugin-declarative-form-controls.md
@@ -1,0 +1,40 @@
+# Open Plugin Declarative Form Controls Implementation Plan
+
+> **Goal:** Render the standard declarative controls supplied by API plugin providers, including a real Monaco code editor, while preserving compatibility with flat inputs and safely degrading unknown controls.
+
+## Task 1: Normalize supported controls and fallback behavior
+
+**Files:**
+- Modify: `frontend/src/utils/jsonFormSchema.js`
+- Modify: `frontend/tests/jsonFormSchema.test.js`
+
+1. Add failing tests for flat `password`, flat `code_editor`, structured `codeEditor`, and unknown-control fallback.
+2. Normalize `textarea` and `password` to `bfInput` with the corresponding input type.
+3. Normalize `code_editor` to the registered `codeEditor` control.
+4. Preserve rules and reactions while replacing unknown controls with the inferred base widget.
+
+Run:
+
+```bash
+npm run test:json-form-schema
+```
+
+## Task 2: Register the Monaco-backed code editor
+
+**Files:**
+- Create: `frontend/src/components/common/ApiCodeEditor.vue`
+- Modify: `frontend/src/components/common/ApiUniForm.vue`
+- Modify: `tests/plugins/uniform_api/test_api_plugin_vue.py`
+
+1. Add failing source-contract tests for custom component registration and Monaco wrapping.
+2. Implement a `v-model` compatible wrapper around `FullCodeEditor`.
+3. Register `codeEditor` through `createForm({ components })`.
+4. Propagate language, height, readonly, disabled, and minimap options.
+
+## Task 3: Document and verify
+
+**Files:**
+- Modify: `docs/specs/2026-06-26-sops-open-plugin-full-capability-design.md`
+- Modify: `docs/guide/api_plugin.md`
+
+Document the standard-control vocabulary and the fallback boundary, then run focused Python tests, frontend schema tests, ESLint, and the development build.

--- a/docs/specs/2026-06-26-sops-open-plugin-full-capability-design.md
+++ b/docs/specs/2026-06-26-sops-open-plugin-full-capability-design.md
@@ -142,6 +142,20 @@ V4.0.0 不新增插件类型，也不新增独立入口。用户仍按普通 API
 - `docs/specs/2026-04-20-sops-open-plugin-frontend-interaction-design.md`
 - `docs/guide/sops_open_plugin_frontend_contract.md`
 
+### 6.2 声明式表单控件
+
+V4 插件详情可携带可选 `form_schema`。BKFlow 优先使用该 schema，并仅渲染已注册的标准控件；没有 `form_schema` 时继续从 `inputs` 生成兼容表单。
+
+本轮标准控件包括：
+
+- `input / textarea / password / codeEditor`
+- `select / radio / checkbox / switcher`
+- `table`
+
+`codeEditor` 复用 BKFlow 现有 Monaco 能力，通过 API 插件表单专用包装组件接入 `@blueking/bkui-form`，支持语言、只读状态和稳定高度。所有控件配置必须是 JSON 可序列化数据；BKFlow 不获取、不解析、不执行插件提供方的旧表单 JavaScript。
+
+未知控件名必须回退到按 JSON Schema 类型推导的基础控件，避免渲染空白自定义标签。`tree / upload / cascader / category / combine` 等依赖动态数据或动作函数的控件，待统一数据源协议落地后再开放，不在本轮宣称原生等价。
+
 ## 7. 测试与验收（BKFlow 侧）
 
 - execute body 携带 `context`；老来源不带 context 时仍可正常执行（兼容回归）。

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "build": "cross-env npm run build:production",
     "build:development": "cross-env DEV_VAR=development webpack --config ./build/webpack.prod.conf.js",
     "build:production": "cross-env DEV_VAR=production webpack --config ./build/webpack.prod.conf.js",
+    "test:json-form-schema": "node tests/jsonFormSchema.test.js",
     "lint": "eslint --ext .js,.vue src/",
     "fix": "eslint --fix --ext .js,.vue src/"
   },

--- a/frontend/src/components/common/ApiCodeEditor.vue
+++ b/frontend/src/components/common/ApiCodeEditor.vue
@@ -1,0 +1,78 @@
+<template>
+  <div
+    class="api-code-editor"
+    :style="{ height: editorHeight }">
+    <FullCodeEditor
+      :value="value"
+      :options="editorOptions"
+      @blur="$emit('blur')"
+      @input="$emit('input', $event)" />
+  </div>
+</template>
+
+<script>
+  import FullCodeEditor from './FullCodeEditor.vue';
+
+  export default {
+    name: 'ApiCodeEditor',
+    components: {
+      FullCodeEditor,
+    },
+    props: {
+      value: {
+        type: String,
+        default: '',
+      },
+      language: {
+        type: String,
+        default: 'plaintext',
+      },
+      height: {
+        type: [String, Number],
+        default: '320px',
+      },
+      showMiniMap: {
+        type: Boolean,
+        default: false,
+      },
+      options: {
+        type: Object,
+        default: () => ({}),
+      },
+      disabled: {
+        type: Boolean,
+        default: false,
+      },
+      readonly: {
+        type: Boolean,
+        default: false,
+      },
+      readOnly: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    computed: {
+      editorHeight() {
+        return typeof this.height === 'number' ? `${this.height}px` : this.height;
+      },
+      editorOptions() {
+        return {
+          ...this.options,
+          language: this.language,
+          readOnly: this.disabled || this.readonly || this.readOnly,
+          minimap: {
+            ...(this.options.minimap || {}),
+            enabled: this.showMiniMap,
+          },
+        };
+      },
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  .api-code-editor {
+    min-height: 160px;
+  }
+</style>

--- a/frontend/src/components/common/ApiUniForm.vue
+++ b/frontend/src/components/common/ApiUniForm.vue
@@ -125,9 +125,14 @@
   import { mapActions } from 'vuex';
   import jsonFormSchema from '@/utils/jsonFormSchema.js';
   import tools from '@/utils/tools.js';
+  import ApiCodeEditor from './ApiCodeEditor.vue';
   import createForm from '@blueking/bkui-form';
   import '@blueking/bkui-form/dist/bkui-form.css';
-  const BkUniForm = createForm();
+  const BkUniForm = createForm({
+    components: {
+      codeEditor: ApiCodeEditor,
+    },
+  });
   export default {
     name: '',
     components: {

--- a/frontend/src/utils/jsonFormSchema.js
+++ b/frontend/src/utils/jsonFormSchema.js
@@ -7,6 +7,14 @@ function getDataType(type) {
   return 'string';
 }
 
+function getSourceType(type) {
+  if (['boolean', 'bool'].includes(type)) return 'bool';
+  if (['integer', 'number', 'int', 'float'].includes(type)) return 'int';
+  if (['array', 'list'].includes(type)) return 'list';
+  if (['object', 'json'].includes(type)) return 'json';
+  return 'string';
+}
+
 function createBaseProperty(cur, type, formType, config) {
   const { name, desc, options } = cur;
 
@@ -64,15 +72,16 @@ function getCompType(type, formType, options) {
 function setComponentProps(acc, cur, key, config) {
   const { multiple, hint, allow_create: allowCreate, options, type, form_type: formType } = cur;
   const { name: compType } = acc[key]['ui:component'];
+  const safeOptions = Array.isArray(options) ? options : [];
 
   if (compType === 'select') {
-    const dataSource = options.map((item) => {
+    const dataSource = safeOptions.map((item) => {
       const result = {
         label: item.text || item,
-        value: item.value || item,
+        value: item && Object.prototype.hasOwnProperty.call(item, 'value') ? item.value : item,
       };
       return result;
-    }) || [];
+    });
     acc[key].type = multiple ? 'array' :  acc[key].type;
     acc[key]['ui:component'].props = {
       ...config,
@@ -85,10 +94,10 @@ function setComponentProps(acc, cur, key, config) {
     acc[key]['ui:props'] = {
       ...config,
     };
-    const dataSource = options.map(item => ({
+    const dataSource = safeOptions.map(item => ({
       label: item.text || item,
-      value: item.value || item,
-    })) || [];
+      value: item && Object.prototype.hasOwnProperty.call(item, 'value') ? item.value : item,
+    }));
     acc[key]['ui:component'].props = { datasource: dataSource };
   } else if (['int', 'string', 'textarea'].includes(type)) {
     // 区分文本框和数字框
@@ -155,7 +164,9 @@ function getProperties(data = [], config = {}) {
 
     if (metaDesc) acc[key].metaDesc = metaDesc;
     if (required) acc[key]['ui:rules'] = createValidationRules(type);
-    if (cur.default) acc[key].default = getDefaultVal(cur.default, type);
+    if (Object.prototype.hasOwnProperty.call(cur, 'default')) {
+      acc[key].default = getDefaultVal(cur.default, type);
+    }
 
     if (formType === 'table') {
       setTableProps(acc, cur, key, config);
@@ -166,7 +177,106 @@ function getProperties(data = [], config = {}) {
   }, {});
 }
 
+function schemaPropertyToInput(key, property, required) {
+  const type = getSourceType(property.type);
+  const input = {
+    key,
+    name: property.title || key,
+    desc: property.description || '',
+    type,
+    required,
+  };
+  if (Object.prototype.hasOwnProperty.call(property, 'default')) {
+    input.default = property.default;
+  }
+
+  const itemSchema = property.items || {};
+  const options = property.enum || itemSchema.enum;
+  if (Array.isArray(options)) input.options = options;
+  if (type === 'list' && itemSchema.type === 'object') {
+    const itemRequired = new Set(itemSchema.required || []);
+    input.form_type = 'table';
+    input.table = {
+      fields: Object.entries(itemSchema.properties || {}).map(([itemKey, item]) => (
+        schemaPropertyToInput(itemKey, item, itemRequired.has(itemKey))
+      )),
+      meta: {},
+    };
+  }
+  return input;
+}
+
+function mergeStructuredProperty(fallback, property, config) {
+  const merged = {
+    ...fallback,
+    ...property,
+    sourceType: property.sourceType || fallback.sourceType,
+    formType: property.formType || fallback.formType,
+    extend: {
+      ...fallback.extend,
+      ...(property.extend || {}),
+    },
+  };
+  const customComponent = property['ui:component'];
+  if (customComponent) {
+    merged['ui:component'] = {
+      ...fallback['ui:component'],
+      ...customComponent,
+      props: {
+        ...(fallback['ui:component'].props || {}),
+        ...(customComponent.props || {}),
+        ...config,
+      },
+    };
+  }
+  return merged;
+}
+
+function normalizeStructuredProperties(properties = {}, required = [], config = {}) {
+  const requiredFields = new Set(required);
+  return Object.entries(properties).reduce((acc, [key, rawProperty]) => {
+    const property = { ...rawProperty };
+    if (property.items?.type === 'object') {
+      property.items = {
+        ...property.items,
+        properties: normalizeStructuredProperties(
+          property.items.properties,
+          property.items.required,
+          config,
+        ),
+      };
+    }
+    if (property.type === 'object' && property.properties) {
+      property.properties = normalizeStructuredProperties(property.properties, property.required, config);
+    }
+
+    const input = schemaPropertyToInput(key, property, requiredFields.has(key));
+    const fallback = getProperties([input], config)[key];
+    acc[key] = mergeStructuredProperty(fallback, property, config);
+    return acc;
+  }, {});
+}
+
+function normalizeStructuredFormSchema(data, config) {
+  const formSchema = data.form_schema;
+  const schema = {
+    ...formSchema,
+    title: formSchema.title || data.id,
+    description: formSchema.description || data.desc || '',
+    type: 'object',
+  };
+  schema.properties = normalizeStructuredProperties(
+    formSchema.properties,
+    formSchema.required,
+    config,
+  );
+  return schema;
+}
+
 export default function jsonFormSchema(data, config = {}) {
+  if (data.form_schema?.properties) {
+    return normalizeStructuredFormSchema(data, config);
+  }
   const { id, desc, inputs } = data;
   if (!Array.isArray(inputs)) return {};
   const keys = inputs.reduce((acc, cur) => {

--- a/frontend/src/utils/jsonFormSchema.js
+++ b/frontend/src/utils/jsonFormSchema.js
@@ -1,5 +1,31 @@
 import tools from './tools';
 
+const SUPPORTED_COMPONENTS = new Set([
+  'button',
+  'select',
+  'radio',
+  'checkbox',
+  'table',
+  'group',
+  'bfArray',
+  'tab',
+  'collapse',
+  'switcher',
+  'color',
+  'bfInput',
+  'input',
+  'bk-input',
+  'bk-date-picker',
+  'codeEditor',
+]);
+
+const COMPONENT_ALIASES = {
+  textarea: { name: 'bfInput', props: { type: 'textarea' } },
+  password: { name: 'bfInput', props: { type: 'password' } },
+  code_editor: { name: 'codeEditor', props: {} },
+  'code-editor': { name: 'codeEditor', props: {} },
+};
+
 function getDataType(type) {
   if (type === 'bool') return 'boolean';
   if (type === 'int') return 'number';
@@ -58,7 +84,13 @@ function getCompType(type, formType, options) {
   let compType = 'bfInput';
   // 支持表单类型
   if (formType) {
-    compType = ['input', 'textarea'].includes(formType) ? compType : formType;
+    if (['input', 'textarea', 'password'].includes(formType)) {
+      compType = 'bfInput';
+    } else if (['code_editor', 'code-editor'].includes(formType)) {
+      compType = 'codeEditor';
+    } else {
+      compType = formType;
+    }
   } else if (type === 'list') {
     compType = formType === 'time_range' ? 'datetimerange' : 'checkbox';
     compType = formType === 'table' ? 'table' : compType;
@@ -99,10 +131,16 @@ function setComponentProps(acc, cur, key, config) {
       value: item && Object.prototype.hasOwnProperty.call(item, 'value') ? item.value : item,
     }));
     acc[key]['ui:component'].props = { datasource: dataSource };
+  } else if (compType === 'codeEditor') {
+    acc[key]['ui:component'].props = {
+      ...config,
+      language: 'plaintext',
+    };
   } else if (['int', 'string', 'textarea'].includes(type)) {
     // 区分文本框和数字框
     let inputType = type === 'int' ? 'number' : 'text';
     inputType = formType === 'textarea' ? 'textarea' : inputType;
+    inputType = formType === 'password' ? 'password' : inputType;
     acc[key]['ui:component'].props = {
       ...config,
       placeholder: hint,
@@ -216,14 +254,19 @@ function mergeStructuredProperty(fallback, property, config) {
       ...fallback.extend,
       ...(property.extend || {}),
     },
+    'ui:component': fallback['ui:component'],
   };
   const customComponent = property['ui:component'];
-  if (customComponent) {
+  const alias = COMPONENT_ALIASES[customComponent?.name];
+  const normalizedName = alias?.name || customComponent?.name;
+  if (SUPPORTED_COMPONENTS.has(normalizedName)) {
     merged['ui:component'] = {
       ...fallback['ui:component'],
       ...customComponent,
+      name: normalizedName,
       props: {
         ...(fallback['ui:component'].props || {}),
+        ...(alias?.props || {}),
         ...(customComponent.props || {}),
         ...config,
       },

--- a/frontend/tests/jsonFormSchema.test.js
+++ b/frontend/tests/jsonFormSchema.test.js
@@ -88,6 +88,68 @@ function testFlatInputsRemainCompatible() {
   assert.deepStrictEqual(schema.properties.targets['ui:component'].props.datasource, []);
 }
 
+function testFlatStandardCustomControlsAreNormalized() {
+  const schema = jsonFormSchema({
+    id: 'plugin-demo',
+    inputs: [
+      { key: 'password', name: 'Password', type: 'string', form_type: 'password' },
+      { key: 'script', name: 'Script', type: 'string', form_type: 'code_editor' },
+    ],
+  });
+
+  assert.strictEqual(schema.properties.password['ui:component'].name, 'bfInput');
+  assert.strictEqual(schema.properties.password['ui:component'].props.type, 'password');
+  assert.strictEqual(schema.properties.script['ui:component'].name, 'codeEditor');
+}
+
+function testStructuredCodeEditorPreservesDeclarativeProps() {
+  const schema = jsonFormSchema({
+    id: 'plugin-demo',
+    form_schema: {
+      type: 'object',
+      properties: {
+        script: {
+          type: 'string',
+          'ui:component': {
+            name: 'code_editor',
+            props: { language: 'shell', height: '400px' },
+          },
+        },
+      },
+    },
+  });
+
+  assert.strictEqual(schema.properties.script['ui:component'].name, 'codeEditor');
+  assert.strictEqual(schema.properties.script['ui:component'].props.language, 'shell');
+  assert.strictEqual(schema.properties.script['ui:component'].props.height, '400px');
+}
+
+function testUnknownStructuredControlFallsBackWithoutDroppingBehavior() {
+  const reaction = { source: 'mode', effect: 'update' };
+  const rules = [{ required: true, message: 'required' }];
+  const schema = jsonFormSchema({
+    id: 'plugin-demo',
+    form_schema: {
+      type: 'object',
+      properties: {
+        content: {
+          type: 'string',
+          'ui:component': { name: 'legacy_magic_editor', props: { theme: 'dark' } },
+          'ui:reactions': [reaction],
+          'ui:rules': rules,
+        },
+      },
+    },
+  });
+
+  assert.strictEqual(schema.properties.content['ui:component'].name, 'bfInput');
+  assert.deepStrictEqual(schema.properties.content['ui:reactions'], [reaction]);
+  assert.deepStrictEqual(schema.properties.content['ui:rules'], rules);
+}
+
 testStructuredFormSchemaTakesPrecedence();
 testFlatInputsRemainCompatible();
+testFlatStandardCustomControlsAreNormalized();
+testStructuredCodeEditorPreservesDeclarativeProps();
+testUnknownStructuredControlFallsBackWithoutDroppingBehavior();
 console.log('jsonFormSchema tests passed');

--- a/frontend/tests/jsonFormSchema.test.js
+++ b/frontend/tests/jsonFormSchema.test.js
@@ -1,0 +1,93 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const babel = require('@babel/core');
+
+function loadJsonFormSchema() {
+  const filePath = path.resolve(__dirname, '../src/utils/jsonFormSchema.js');
+  const source = fs.readFileSync(filePath, 'utf8');
+  const transformed = babel.transformSync(source, {
+    plugins: ['@babel/plugin-transform-modules-commonjs'],
+  });
+  const module = { exports: {} };
+  const localRequire = (id) => {
+    if (id === './tools') {
+      return {
+        __esModule: true,
+        default: {
+          checkIsJSON(value) {
+            if (typeof value !== 'string') return false;
+            try {
+              JSON.parse(value);
+              return true;
+            } catch (error) {
+              return false;
+            }
+          },
+        },
+      };
+    }
+    return require(id);
+  };
+  // eslint-disable-next-line no-new-func
+  const compile = new Function('require', 'module', 'exports', transformed.code);
+  compile(localRequire, module, module.exports);
+  return module.exports.default;
+}
+
+const jsonFormSchema = loadJsonFormSchema();
+
+function testStructuredFormSchemaTakesPrecedence() {
+  const schema = jsonFormSchema({
+    id: 'plugin-demo',
+    desc: 'demo',
+    inputs: [{ key: 'mode', name: 'Mode', type: 'string' }],
+    form_schema: {
+      type: 'object',
+      required: ['mode'],
+      properties: {
+        mode: {
+          type: 'string',
+          title: 'Mode',
+          'ui:component': {
+            name: 'select',
+            props: {
+              datasource: [{ label: 'Sync', value: 'sync' }],
+            },
+          },
+          'ui:reactions': [{ source: 'other', effect: 'update' }],
+        },
+      },
+    },
+  }, { disabled: true });
+
+  assert.strictEqual(schema.properties.mode['ui:component'].name, 'select');
+  assert.deepStrictEqual(schema.properties.mode['ui:component'].props.datasource, [
+    { label: 'Sync', value: 'sync' },
+  ]);
+  assert.strictEqual(schema.properties.mode['ui:component'].props.disabled, true);
+  assert.deepStrictEqual(schema.properties.mode['ui:reactions'], [{ source: 'other', effect: 'update' }]);
+  assert.strictEqual(schema.properties.mode.extend.can_hook, true);
+}
+
+function testFlatInputsRemainCompatible() {
+  const schema = jsonFormSchema({
+    id: 'plugin-demo',
+    inputs: [
+      { key: 'retry', name: 'Retry', type: 'int', default: 0 },
+      { key: 'enabled', name: 'Enabled', type: 'bool', default: false },
+      { key: 'targets', name: 'Targets', type: 'list' },
+    ],
+  });
+
+  assert.strictEqual(schema.properties.retry['ui:component'].props.type, 'number');
+  assert.strictEqual(schema.properties.retry.default, 0);
+  assert.strictEqual(schema.properties.enabled['ui:component'].name, 'switcher');
+  assert.strictEqual(schema.properties.enabled.default, false);
+  assert.deepStrictEqual(schema.properties.targets['ui:component'].props.datasource, []);
+}
+
+testStructuredFormSchemaTakesPrecedence();
+testFlatInputsRemainCompatible();
+console.log('jsonFormSchema tests passed');

--- a/tests/plugins/uniform_api/test_api_plugin_vue.py
+++ b/tests/plugins/uniform_api/test_api_plugin_vue.py
@@ -26,3 +26,15 @@ def test_each_api_plugin_list_owns_its_scroll_handler():
 
     assert '@scroll="handleApiPluginScroll"' in source
     assert "querySelector('.api-list')" not in source
+
+
+def test_api_uniform_registers_monaco_code_editor():
+    frontend_root = Path(__file__).resolve().parents[3] / "frontend" / "src"
+    uniform_source = (frontend_root / "components" / "common" / "ApiUniForm.vue").read_text(encoding="utf-8")
+    editor_source = (frontend_root / "components" / "common" / "ApiCodeEditor.vue").read_text(encoding="utf-8")
+
+    assert "import ApiCodeEditor from './ApiCodeEditor.vue'" in uniform_source
+    assert "createForm({" in uniform_source
+    assert "codeEditor: ApiCodeEditor" in uniform_source
+    assert "<FullCodeEditor" in editor_source
+    assert "@input=\"$emit('input', $event)\"" in editor_source

--- a/tests/plugins/uniform_api/test_uniform_api_client.py
+++ b/tests/plugins/uniform_api/test_uniform_api_client.py
@@ -176,6 +176,17 @@ class TestUniformAPIClient:
             "url": "https://bk-sops.example/open-plugin-runs",
             "methods": ["POST"],
             "inputs": [],
+            "form_schema": {
+                "type": "object",
+                "required": ["biz_id"],
+                "properties": {
+                    "biz_id": {
+                        "type": "number",
+                        "title": "业务 ID",
+                        "ui:component": {"name": "bk-input", "props": {"type": "number"}},
+                    }
+                },
+            },
             "outputs": [{"name": "作业实例 ID", "key": "job_instance_id"}],
             "polling": {
                 "url": "https://bk-sops.example/open-plugin-runs/status",


### PR DESCRIPTION
## 问题

V4 API 插件详情当前只按扁平 `inputs` 生成表单；无法识别标准 JSON Schema 类型，也会丢失第三方插件的结构化 UI 元数据，最终多数参数退化为普通输入框。

## 修改

- uniform_api detail 协议增加可选 `form_schema`，保留 `inputs` 兼容回退。
- 优先渲染结构化表单，保留 `ui:component`、`ui:rules`、`ui:reactions` 和嵌套表格配置。
- 补齐 JSON Schema 类型转换，并修复空选项、`0`、`false` 默认值兼容。
- 增加前端转换单测和协议校验用例，更新接入文档。

## 验证

- `pytest tests/plugins/uniform_api tests/plugins/components/collections/uniform_api_test/test_v4_0_0.py -v`：25 passed
- `npm run test:json-form-schema`：passed
- 定向 ESLint：passed
- `npm run build:development`：compiled successfully（仅项目既有 warnings）