### PR TITLE
fix(ci): 加固可信贡献者自动代码审查

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -11,25 +11,55 @@ jobs:
   security-check:
     name: 安全检查
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       is_safe: ${{ steps.check.outputs.is_safe }}
       author_association: ${{ steps.check.outputs.author_association }}
+      author_permission: ${{ steps.check.outputs.author_permission }}
+      sender_permission: ${{ steps.check.outputs.sender_permission }}
     steps:
       - name: 检查贡献者身份
         id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          EVENT_SENDER: ${{ github.event.sender.login }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
         run: |
-          echo "作者关联: ${{ github.event.pull_request.author_association }}"
-          # 允许的身份：OWNER（所有者）、MEMBER（成员）、COLLABORATOR（协作者）
-          if [[ "${{ github.event.pull_request.author_association }}" == "OWNER" ]] || \
-             [[ "${{ github.event.pull_request.author_association }}" == "MEMBER" ]] || \
-             [[ "${{ github.event.pull_request.author_association }}" == "COLLABORATOR" ]]; then
-            echo "✅ 可信任的贡献者，允许自动审查"
-            echo "is_safe=true" >> $GITHUB_OUTPUT
+          get_permission() {
+            local username="$1"
+            gh api "repos/${REPOSITORY}/collaborators/${username}/permission" \
+              --jq '.permission' 2>/dev/null || echo "none"
+          }
+
+          is_trusted_permission() {
+            # GitHub 的 permission 字段会把 maintain 映射为 write。
+            case "$1" in
+              admin|write) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          AUTHOR_PERMISSION="$(get_permission "$PR_AUTHOR")"
+          SENDER_PERMISSION="$(get_permission "$EVENT_SENDER")"
+
+          echo "作者关联: $AUTHOR_ASSOCIATION"
+          echo "PR 作者 $PR_AUTHOR 的仓库权限: $AUTHOR_PERMISSION"
+          echo "事件触发者 $EVENT_SENDER 的仓库权限: $SENDER_PERMISSION"
+
+          if is_trusted_permission "$AUTHOR_PERMISSION" && \
+            is_trusted_permission "$SENDER_PERMISSION"; then
+            echo "✅ PR 作者和事件触发者均具备写权限，允许自动审查"
+            echo "is_safe=true" >> "$GITHUB_OUTPUT"
           else
-            echo "⚠️ 外部贡献者，需要手动批准"
-            echo "is_safe=false" >> $GITHUB_OUTPUT
+            echo "⚠️ PR 作者或事件触发者不具备写权限，跳过自动审查"
+            echo "is_safe=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "author_association=${{ github.event.pull_request.author_association }}" >> $GITHUB_OUTPUT
+          echo "author_association=$AUTHOR_ASSOCIATION" >> "$GITHUB_OUTPUT"
+          echo "author_permission=$AUTHOR_PERMISSION" >> "$GITHUB_OUTPUT"
+          echo "sender_permission=$SENDER_PERMISSION" >> "$GITHUB_OUTPUT"
   # 第二步：代码审查（只对可信贡献者自动运行）
   code-review:
     name: 自动代码审查
@@ -48,6 +78,9 @@ jobs:
           fetch-depth: 0
           # 关键：检出 PR 的代码，而不是默认分支
           ref: ${{ github.event.pull_request.head.sha }}
+          # 前置安全检查已确认 PR 作者与本次事件触发者均具备写权限。
+          # CodeBuddy 需要完整 PR 工作区进行跨文件审查，因此显式允许可信 fork 的 Head checkout。
+          allow-unsafe-pr-checkout: true
 
       - name: 设置 Node.js 环境
         uses: actions/setup-node@v4


### PR DESCRIPTION
## 问题

`actions/checkout@v4` 新增了 `pull_request_target` 下 fork Head 的安全保护，现有 CodeBuddy workflow 会在检出可信贡献者的 fork PR 时直接失败，自动代码审查尚未启动。

## 修改

- 安全检查不再仅依赖 `author_association`，改为通过 GitHub API 获取实际仓库权限。
- PR 作者和本次事件触发者必须同时具备 `write` 或 `admin` 权限；API 查询失败时按无权限处理。
- 安全检查 job 收敛为只读仓库权限，并输出作者与触发者权限用于排障。
- 在通过前置权限检查后显式启用 `allow-unsafe-pr-checkout: true`。
- 保留 PR Head 完整检出、CodeBuddy 本地跨文件读取、完整 diff 获取和 PR review 提交能力。

## 影响

- 本 PR 独立基于 `master`，不修改任何存量 PR 的分支或提交。
- 合入后仅影响 `master` 上后续触发的 CodeBuddy 自动审查 workflow。
- 具备写权限的可信贡献者仍可获得原有完整代码审查；无写权限或权限查询失败的事件将跳过自动审查。

## 验证

- `actionlint v1.7.12`：通过；仅忽略其内置旧版 checkout 元数据未识别 `allow-unsafe-pr-checkout` 的已确认误报。
- 官方 `actions/checkout@v4/action.yml`：已确认包含 `allow-unsafe-pr-checkout` 输入。
- 权限门禁模拟：`admin/write` 放行，`read/write` 拒绝，`admin/none` 拒绝。
- 完整审查能力不变量：PR Head、CodeBuddy 完整权限、`gh pr diff`、`gh pr review` 均保留。
- `git diff --check`：通过。

## CI 说明

本 PR 自身的 CodeBuddy check 仍会使用 `master` 上尚未修复的 `pull_request_target` workflow，因此预期继续在 fork Head checkout 处失败。该 run 的日志中仍是旧的 `author_association` 判断且 `allow-unsafe-pr-checkout: false`；新 workflow 需要合入 `master` 后，由后续 PR 事件完成线上验证。
