### PR TITLE
fix(debug): 修复调试状态同步异常

### DIFF
--- a/bkflow/task/models.py
+++ b/bkflow/task/models.py
@@ -97,8 +97,9 @@ class TaskInstanceManager(models.Manager):
         """
         pipeline 注入原始模板节点 ID
         """
-        for act_id, act in pipeline_tree[PE.activities].items():
-            act["template_node_id"] = act["template_node_id"] = act.get("template_node_id") or act_id
+        for node_type in (PE.activities, PE.gateways):
+            for node_id, node in pipeline_tree.get(node_type, {}).items():
+                node["template_node_id"] = node.get("template_node_id") or node_id
 
     def create_instance(self, *args, **kwargs):
         """

--- a/bkflow/task/operations.py
+++ b/bkflow/task/operations.py
@@ -542,6 +542,27 @@ class TaskOperation:
                 schedule_type = schedule_types.get((node.get("id"), node.get("version")))
                 if schedule_type:
                     node["schedule_type"] = schedule_type
+                    continue
+                if node.get("state") != bamboo_engine_states.RUNNING or not node.get("id"):
+                    continue
+                try:
+                    if not runtime.get_sleep_process_info_with_current_node_id(node["id"]):
+                        continue
+                    engine_node = runtime.get_node(node["id"])
+                    service = runtime.get_service(
+                        code=engine_node.code,
+                        version=engine_node.version,
+                        name=engine_node.name,
+                    )
+                    inferred_type = service.schedule_type()
+                    if inferred_type:
+                        node["schedule_type"] = inferred_type.name
+                except Exception:
+                    logger.warning(
+                        "[get_task_states] infer schedule type failed, node_id=%s",
+                        node["id"],
+                        exc_info=True,
+                    )
 
         def collect_fail_nodes(task_status: dict) -> list:
             task_status["ex_data"] = {}

--- a/bkflow/task/views.py
+++ b/bkflow/task/views.py
@@ -380,8 +380,11 @@ class TaskInstanceViewSet(
     @validate_task_info
     def get_node_id_map(self, request, *args, **kwargs):
         task_instance = self.get_object()
-        activities = (task_instance.execution_data or {}).get("activities", {})
-        mapping = {act.get("template_node_id", act_id): act_id for act_id, act in activities.items()}
+        execution_data = task_instance.execution_data or {}
+        mapping = {}
+        for node_type in ("activities", "gateways"):
+            for node_id, node in execution_data.get(node_type, {}).items():
+                mapping[node.get("template_node_id", node_id)] = node_id
         return Response(mapping)
 
     @swagger_auto_schema(methods=["get"], operation_description="任务全局变量查询")

--- a/bkflow/template/debug/service.py
+++ b/bkflow/template/debug/service.py
@@ -567,6 +567,15 @@ class DebugService:
             ns.save()
 
         engine_state = data.get("state")
+        if engine_state == "FAILED":
+            state_errors = data.get("ex_data") if isinstance(data.get("ex_data"), dict) else {}
+            for runtime_id, child in children.items():
+                if child.get("state") != "FAILED" or runtime_errors.get(runtime_id) or state_errors.get(runtime_id):
+                    continue
+                detail = client.get_task_node_detail(task_id, runtime_id, data={"include_data": True})
+                ddata = detail.get("data", {}) if detail.get("result") else {}
+                if ddata.get("ex_data"):
+                    runtime_errors[runtime_id] = ddata["ex_data"]
         ctx.last_task_id = task_id
         ctx.last_run_type = ctx.active_run_type or ctx.last_run_type or "global"
         if engine_state in ENGINE_RUN_STATE_MAP:
@@ -639,19 +648,40 @@ class DebugService:
             data={"template_id": self.template_id, "space_id": self.space_id, "create_method": "DEBUG"}
         )
         items = (result.get("data") or {}).get("results", [])
+        task_ids = [item["id"] for item in items if item.get("id") is not None]
+        engine_states = {}
+        if task_ids:
+            states_result = client.get_tasks_states(data={"task_ids": task_ids, "space_id": self.space_id})
+            if states_result.get("result"):
+                engine_states = states_result.get("data") or {}
+        status_map = {
+            "CREATED": "created",
+            "READY": "created",
+            "RUNNING": "running",
+            "SUSPENDED": "paused",
+            "NODE_SUSPENDED": "paused",
+            "FINISHED": "finished",
+            "FAILED": "failed",
+            "REVOKED": "revoked",
+            "EXPIRED": "expired",
+        }
         runs = []
         for item in items:
-            if item.get("is_revoked"):
-                run_status = "revoked"
-            elif item.get("is_finished"):
-                run_status = "finished"
-            elif item.get("is_started"):
-                run_status = "running"
-            else:
-                run_status = "created"
+            task_id = item.get("id")
+            engine_state = (engine_states.get(task_id) or engine_states.get(str(task_id)) or {}).get("state")
+            run_status = status_map.get(engine_state)
+            if not run_status:
+                if item.get("is_revoked"):
+                    run_status = "revoked"
+                elif item.get("is_finished"):
+                    run_status = "finished"
+                elif item.get("is_started"):
+                    run_status = "running"
+                else:
+                    run_status = "created"
             runs.append(
                 {
-                    "task_id": item.get("id"),
+                    "task_id": task_id,
                     "operator": item.get("creator") or item.get("executor"),
                     "started_at": item.get("start_time") or item.get("create_time"),
                     "status": run_status,

--- a/tests/engine/task/test_node_id_map.py
+++ b/tests/engine/task/test_node_id_map.py
@@ -56,8 +56,29 @@ class TestGetNodeIdMap:
 
     def test_get_node_id_map_returns_template_to_runtime_mapping(self):
         tree = build_default_pipeline_tree()
+        original_flow_id = tree["start_event"]["outgoing"]
+        original_act_id = next(iter(tree["activities"]))
+        gateway_id = "gateway_template_id"
+        gateway_flow_id = "gateway_flow_id"
+        tree["flows"][original_flow_id]["target"] = gateway_id
+        tree["flows"][gateway_flow_id] = {
+            "id": gateway_flow_id,
+            "is_default": True,
+            "source": gateway_id,
+            "target": original_act_id,
+        }
+        tree["activities"][original_act_id]["incoming"] = [gateway_flow_id]
+        tree["gateways"][gateway_id] = {
+            "id": gateway_id,
+            "type": "ExclusiveGateway",
+            "incoming": original_flow_id,
+            "outgoing": [gateway_flow_id],
+            "conditions": {},
+            "default_condition": {"flow_id": gateway_flow_id},
+        }
         # create_instance 会就地修改 tree（replace_all_id），故提前捕获原始模板节点 id
         original_act_ids = set(tree["activities"].keys())
+        original_gateway_ids = set(tree["gateways"].keys())
         instance = TaskInstance.objects.create_instance(
             pipeline_tree=tree, space_id=1, create_method="DEBUG", creator="admin"
         )
@@ -69,11 +90,13 @@ class TestGetNodeIdMap:
         assert response.status_code == status.HTTP_200_OK
         mapping = response.data["data"]
         # 每个模板节点 id 都应出现在映射的 key 中
-        assert set(mapping.keys()) == original_act_ids
+        assert set(mapping.keys()) == original_act_ids | original_gateway_ids
         # 运行时 id 应与模板 id 不同，证明确实发生了重映射
         assert all(mapping[k] != k for k in mapping)
         # value 应为任务执行数据中真实的运行时节点 id
-        runtime_ids = set(instance.execution_data["activities"].keys())
+        runtime_ids = set(instance.execution_data["activities"].keys()) | set(
+            instance.execution_data["gateways"].keys()
+        )
         assert set(mapping.values()) == runtime_ids
 
     def test_get_node_id_map_returns_empty_when_no_activities(self):

--- a/tests/engine/task/test_task_operations.py
+++ b/tests/engine/task/test_task_operations.py
@@ -438,6 +438,45 @@ class TestTaskOperationComplete:
 
         assert result.data["children"]["node_1"]["schedule_type"] == schedule_type.name
 
+    def test_get_task_states_infers_schedule_type_for_sleeping_service(self, mocker):
+        task_instance = TaskInstance.objects.create(
+            name="test_task", space_id=1, instance_id=node_uniqid(), is_started=True
+        )
+        mock_states = {
+            task_instance.instance_id: {
+                "id": task_instance.instance_id,
+                "state": bamboo_engine_states.RUNNING,
+                "version": "root-v1",
+                "children": {
+                    "node_1": {
+                        "id": "node_1",
+                        "state": bamboo_engine_states.RUNNING,
+                        "version": "v1",
+                        "children": {},
+                    }
+                },
+            }
+        }
+        mocker.patch(
+            "bamboo_engine.api.get_pipeline_states",
+            return_value=EngineAPIResult(result=True, data=mock_states, message="success"),
+        )
+        mocker.patch(
+            "pipeline.eri.runtime.BambooDjangoRuntime.get_sleep_process_info_with_current_node_id",
+            return_value=mocker.MagicMock(),
+        )
+        mocker.patch(
+            "pipeline.eri.runtime.BambooDjangoRuntime.get_node",
+            return_value=mocker.MagicMock(code="pause_node", version="legacy", name="pause"),
+        )
+        service = mocker.MagicMock()
+        service.schedule_type.return_value = ScheduleType.CALLBACK
+        mocker.patch("pipeline.eri.runtime.BambooDjangoRuntime.get_service", return_value=service)
+
+        result = TaskOperation(task_instance).get_task_states(include_schedule=True)
+
+        assert result.data["children"]["node_1"]["schedule_type"] == ScheduleType.CALLBACK.name
+
     def test_get_task_states_does_not_include_schedule_type_by_default(self, mocker):
         task_instance = TaskInstance.objects.create(
             name="test_task", space_id=1, instance_id=node_uniqid(), is_started=True

--- a/tests/interface/template/debug/test_service_sync.py
+++ b/tests/interface/template/debug/test_service_sync.py
@@ -189,7 +189,7 @@ class TestSyncFromDebugTask:
         assert ctx.last_task_id == 456
         assert ctx.last_run_status == "finished"
 
-    def test_sync_gateway_failure_keeps_task_level_error(self, mocker):
+    def test_sync_gateway_failure_fetches_detail_when_state_ex_data_is_empty(self, mocker):
         svc = DebugService(template_id=1, space_id=10, pipeline_tree=PIPELINE)
         ctx = svc.get_or_create_context()
         svc.sync_node_states()
@@ -207,11 +207,20 @@ class TestSyncFromDebugTask:
             "data": {
                 "state": "FAILED",
                 "children": {"rt_gateway": {"state": "FAILED", "elapsed_time": 0}},
-                "ex_data": {"rt_gateway": "multiple conditions meet"},
+                "ex_data": {},
             },
             "message": "",
         }
-        client.get_node_id_map.return_value = {"result": True, "data": {"A": "rtA"}, "message": ""}
+        client.get_node_id_map.return_value = {
+            "result": True,
+            "data": {"A": "rtA", "G": "rt_gateway"},
+            "message": "",
+        }
+        client.get_task_node_detail.return_value = {
+            "result": True,
+            "data": {"ex_data": "multiple conditions meet", "outputs": []},
+            "message": "",
+        }
         mocker.patch.object(svc, "_task_client", return_value=client)
 
         svc.sync_from_debug_task(ctx)
@@ -228,11 +237,12 @@ class TestSyncFromDebugTask:
             "failures": [
                 {
                     "node_id": "rt_gateway",
-                    "template_node_id": None,
+                    "template_node_id": "G",
                     "message": "multiple conditions meet",
                 }
             ],
         }
+        client.get_task_node_detail.assert_called_once_with(456, "rt_gateway", data={"include_data": True})
 
     def test_sync_returns_early_when_node_id_map_fails(self, mocker):
         """id_map 调用失败：不回写、不释放锁，结束结果可在下次重试"""

--- a/tests/interface/template/debug/test_views_run_ops.py
+++ b/tests/interface/template/debug/test_views_run_ops.py
@@ -103,6 +103,11 @@ class TestRunOpsViews:
             "data": {"results": [{"id": 7, "creator": "admin", "start_time": "t", "is_finished": True}]},
             "message": "",
         }
+        client.get_tasks_states.return_value = {
+            "result": True,
+            "data": {"7": {"state": "FAILED"}},
+            "message": "",
+        }
         mocker.patch.object(DebugService, "_task_client", return_value=client)
 
         view = DebugViewSet.as_view({"get": "history"})
@@ -112,7 +117,8 @@ class TestRunOpsViews:
 
         assert response.status_code == 200
         assert response.data["data"]["runs"][0]["task_id"] == 7
-        assert response.data["data"]["runs"][0]["status"] == "finished"
+        assert response.data["data"]["runs"][0]["status"] == "failed"
+        client.get_tasks_states.assert_called_once_with(data={"task_ids": [7], "space_id": 10})
 
     def test_reset_while_running_returns_standard_error(self, mocker):
         self._patch_tree(mocker)


### PR DESCRIPTION
## 背景

stage 环境重新验证调试功能时发现：

- 暂停节点处于引擎休眠状态，但活跃 Schedule 记录缺失时，调试状态无法识别为 waiting
- 网关执行失败后，调试上下文只保留通用 `task failed`，无法定位具体网关和错误原因
- 已失败的调试任务在历史记录中仍显示为 running/finished

## 修改

- `get_states?include_schedule=true` 在有效 Schedule 未命中时，对运行中且实际休眠的节点从服务定义兜底获取 `schedule_type`
- 创建任务时为活动节点和网关统一注入 `template_node_id`，节点映射接口同时返回网关映射
- 任务失败且状态树缺少 `ex_data` 时，回查失败节点详情并同步真实错误
- 调试历史通过现有批量任务状态接口校准失败、暂停、撤销等状态，并保留原有字段回退逻辑

## 验证

- `tests/engine/task/test_task_operations.py tests/engine/task/test_node_id_map.py`：36 passed
- `tests/interface/template/debug`：76 passed
- `tests/engine/task/test_models.py tests/engine/task/test_debug_create_instance.py tests/engine/task/test_views.py tests/engine/task/test_task_views.py`：116 passed
- pre-commit：black / isort / flake8 / pyupgrade 全部通过

关联需求：#135505027