### PR TITLE
fix(debug): 支持调试任务申请 Token

### DIFF
--- a/bkflow/apigw/serializers/token.py
+++ b/bkflow/apigw/serializers/token.py
@@ -37,17 +37,22 @@ class TokenResourceValidator:
 
     def task_exists(self, task_id):
         client = TaskComponentClient(space_id=self.space_id)
-        query_data = {"id": task_id, "space_id": self.space_id, "limit": 1, "offset": 0}
-        resp = client.task_list(data=query_data)
-        if not resp["result"]:
-            logger.info("[TokenResourceValidator] query task error , resp = {}".format(resp))
+        resp = client.get_task_detail(task_id)
+        if not resp.get("result"):
+            logger.info(
+                "[TokenResourceValidator] query task detail error, code=%s, message=%s",
+                resp.get("code"),
+                resp.get("message"),
+            )
             return False
 
-        logger.info("[TokenResourceValidator] query task success, resp = {}".format(resp))
-        if resp.get("data", {}).get("count", []) == 1:
-            return True
-
-        return False
+        task = resp.get("data") or {}
+        logger.info(
+            "[TokenResourceValidator] query task detail success, task_id=%s, space_id=%s",
+            task.get("id"),
+            task.get("space_id"),
+        )
+        return str(task.get("id")) == str(task_id) and str(task.get("space_id")) == str(self.space_id)
 
     def template_exists(self, template_id):
         return Template.exists(template_id, self.space_id)

--- a/tests/interface/apigw/test_token_resource_validator.py
+++ b/tests/interface/apigw/test_token_resource_validator.py
@@ -1,0 +1,64 @@
+from unittest.mock import patch
+
+from bkflow.apigw.serializers.token import TokenResourceValidator
+
+
+class TestTokenResourceValidator:
+    @patch("bkflow.apigw.serializers.token.TaskComponentClient")
+    def test_task_exists_accepts_debug_task_in_same_space(self, mock_client_cls):
+        client = mock_client_cls.return_value
+        client.task_list.return_value = {
+            "result": True,
+            "data": {"count": 0, "results": []},
+            "code": "0",
+            "message": "",
+        }
+        client.get_task_detail.return_value = {
+            "result": True,
+            "data": {"id": 40, "space_id": 205, "create_method": "DEBUG"},
+            "code": "0",
+            "message": "",
+        }
+
+        validator = TokenResourceValidator(space_id=205, resource_type="TASK", resource_id="40")
+
+        assert validator.task_exists("40") is True
+
+    @patch("bkflow.apigw.serializers.token.TaskComponentClient")
+    def test_task_exists_rejects_task_from_other_space(self, mock_client_cls):
+        mock_client_cls.return_value.get_task_detail.return_value = {
+            "result": True,
+            "data": {"id": 40, "space_id": 206, "create_method": "DEBUG"},
+            "code": "0",
+            "message": "",
+        }
+
+        validator = TokenResourceValidator(space_id=205, resource_type="TASK", resource_id="40")
+
+        assert validator.task_exists("40") is False
+
+    @patch("bkflow.apigw.serializers.token.TaskComponentClient")
+    def test_task_exists_rejects_mismatched_task_id(self, mock_client_cls):
+        mock_client_cls.return_value.get_task_detail.return_value = {
+            "result": True,
+            "data": {"id": 41, "space_id": 205, "create_method": "DEBUG"},
+            "code": "0",
+            "message": "",
+        }
+
+        validator = TokenResourceValidator(space_id=205, resource_type="TASK", resource_id="40")
+
+        assert validator.task_exists("40") is False
+
+    @patch("bkflow.apigw.serializers.token.TaskComponentClient")
+    def test_task_exists_rejects_failed_lookup(self, mock_client_cls):
+        mock_client_cls.return_value.get_task_detail.return_value = {
+            "result": False,
+            "data": None,
+            "code": "404",
+            "message": "not found",
+        }
+
+        validator = TokenResourceValidator(space_id=205, resource_type="TASK", resource_id="40")
+
+        assert validator.task_exists("40") is False


### PR DESCRIPTION
## 背景

stage 环境中，调试任务详情可以正常访问，但以任务 ID 申请 Token 时返回“对应的资源不存在”。日志确认 Token 校验通过任务列表接口查询，而任务列表默认排除 `create_method=DEBUG` 的任务。

## 修改

- Token 任务资源校验改为调用任务详情接口，不再受普通任务列表隐藏规则影响
- 同时校验返回的任务 ID 和 `space_id`，保持跨空间隔离
- 成功日志只记录任务 ID/空间 ID，避免打印完整任务详情
- 新增 DEBUG 任务、跨空间、ID 不一致和查询失败回归测试

## 验证

- `tests/interface/apigw/test_token_resource_validator.py`：4 passed
- black / isort / flake8 / pyupgrade：通过
- compileall / `git diff --check`：通过

## 环境说明

原有 `tests/interface/apigw/test_apply_token.py` 依赖本机 MySQL；当前 `localhost:3306` 未启动，数据库级用例未执行完成。