### PR TITLE
fix(debug): 修复已终止调试的遗留节点状态

### DIFF
--- a/bkflow/template/debug/service.py
+++ b/bkflow/template/debug/service.py
@@ -516,6 +516,11 @@ class DebugService:
         """惰性回写真实调试任务；全局和单步共用同一条状态生命周期。"""
         # 早返回守卫：仅运行中且存在 active_task_id 才同步，避免空闲态构建真实客户端
         if ctx.status not in ("running", "terminating") or not ctx.active_task_id:
+            if ctx.status == "idle" and ctx.last_run_status == "revoked":
+                DebugNodeState.objects.filter(
+                    debug_context=ctx,
+                    status__in=("running", "waiting", "paused"),
+                ).update(status="revoked", waiting_reason="")
             return
         client = self._task_client()
         task_id = ctx.active_task_id

--- a/tests/interface/template/debug/test_service_sync.py
+++ b/tests/interface/template/debug/test_service_sync.py
@@ -233,6 +233,29 @@ class TestSyncFromDebugTask:
         assert ctx.last_run_status == "revoked"
         assert ctx.last_error_detail == {}
 
+    def test_sync_repairs_stale_waiting_node_after_revoked_task_was_released(self, mocker):
+        """兼容发布前遗留状态：锁已释放但等待节点尚未收敛。"""
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=PIPELINE)
+        ctx = svc.get_or_create_context()
+        svc.sync_node_states()
+        ctx.status = "idle"
+        ctx.active_task_id = None
+        ctx.last_task_id = 456
+        ctx.last_run_status = "revoked"
+        ctx.save()
+        DebugNodeState.objects.filter(debug_context=ctx, node_id="A").update(
+            status="waiting",
+            waiting_reason="poll",
+        )
+        task_client = mocker.patch.object(svc, "_task_client")
+
+        svc.sync_from_debug_task(ctx)
+
+        ns = DebugNodeState.objects.get(debug_context=ctx, node_id="A")
+        assert ns.status == "revoked"
+        assert ns.waiting_reason == ""
+        task_client.assert_not_called()
+
     def test_sync_gateway_failure_fetches_detail_when_state_ex_data_is_empty(self, mocker):
         svc = DebugService(template_id=1, space_id=10, pipeline_tree=PIPELINE)
         ctx = svc.get_or_create_context()


### PR DESCRIPTION
## 问题

调试任务在旧版本中已经撤销并释放上下文锁后，可能遗留 `waiting/running/paused` 节点状态。新版本读取这类 `idle + last_run_status=revoked` 上下文时会因缺少 `active_task_id` 直接返回，前端仍显示“调试中”，再次终止则提示“当前没有运行中的调试”。

## 修复

- 读取空闲且最近任务为 `revoked` 的调试上下文时，将遗留活跃节点收敛为 `revoked`。
- 该自愈不再访问引擎，也不影响正常运行中的调试任务及普通流程任务。
- 新增部署前遗留状态的回归用例。

## 验证

- `tests/interface/template/debug`: 80 passed
- `black --check`: passed
- `flake8`: passed
- `git diff --check`: passed