### PR TITLE
fix(debug): 补充调试上下文 Mock 输出回显

### DIFF
--- a/bkflow/template/debug/service.py
+++ b/bkflow/template/debug/service.py
@@ -171,6 +171,9 @@ class DebugService:
                     "node_type": ns.node_type,
                     "execution_mode": ns.execution_mode,
                     "mock_result": ns.mock_result if ns.execution_mode == "mock" else None,
+                    "mock_outputs": (
+                        ns.mock_outputs if ns.execution_mode == "mock" and ns.mock_result == "success" else None
+                    ),
                     "mock_error": ns.mock_error if ns.execution_mode == "mock" and ns.mock_result == "fail" else None,
                     "status": ns.status,
                     "waiting_reason": ns.waiting_reason or None,

--- a/tests/interface/template/debug/test_service_context.py
+++ b/tests/interface/template/debug/test_service_context.py
@@ -101,6 +101,7 @@ class TestDebugServiceContext:
         node_a = view["nodes"][0]
         assert node_a["execution_mode"] == "real"
         assert node_a["mock_result"] is None  # real 模式不返回 mock_result
+        assert node_a["mock_outputs"] is None
         assert node_a["status"] == "not_run"
         assert node_a["can_step"] is True  # Phase 3 前的占位
         assert node_a["log_ref"] is None and node_a["error_detail"] is None
@@ -109,6 +110,19 @@ class TestDebugServiceContext:
         assert view["last_run_type"] is None
         assert view["last_run_status"] == "not_run"
         assert view["last_error_detail"] is None
+
+    def test_build_context_view_returns_mock_outputs_for_success_preset(self):
+        """mock 成功预设刷新后应能回填保存的输出"""
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=PIPELINE)
+        ctx = svc.get_or_create_context()
+        svc.sync_node_states()
+        DebugNodeState.objects.filter(debug_context=ctx, node_id="A").update(
+            execution_mode="mock", mock_result="success", mock_outputs={"response": {"code": 0}}
+        )
+
+        node_a = svc.build_context_view()["nodes"][0]
+
+        assert node_a["mock_outputs"] == {"response": {"code": 0}}
 
     def test_build_context_view_returns_mock_error_for_fail_preset(self):
         """mock 失败预设刷新后应能回填错误文案"""
@@ -124,3 +138,4 @@ class TestDebugServiceContext:
         assert node_a["execution_mode"] == "mock"
         assert node_a["mock_result"] == "fail"
         assert node_a["mock_error"] == "preset boom"
+        assert node_a["mock_outputs"] is None


### PR DESCRIPTION
## 变更说明

- `debug_context` 的 `nodes[]` 新增 `mock_outputs` 字段。
- 节点为成功 Mock 预设时返回已保存的输出，支持页面刷新后回填 Mock 编辑弹窗及底部结果区域。
- 真实执行节点和失败 Mock 节点返回 `null`，避免误展示历史输出。

## 验证

- 调试上下文定向用例：`9 passed`
- 完整调试模块：`81 passed`
- `black`、`flake8`、提交钩子及 `git diff --check` 均通过