### PR TITLE
fix: 避免引擎日志重复写入

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -340,20 +340,20 @@ def logging_addition_settings(logging_dict: dict, environment="prod"):
         "propagate": True,
     }
 
-    logging_dict["loggers"]["pipeline"] = {"handlers": ["root"], "level": "INFO", "propagate": True}
+    logging_dict["loggers"]["pipeline"] = {"handlers": ["root"], "level": "INFO", "propagate": False}
 
     logging_dict["loggers"]["pipeline.eri.log"] = {"handlers": ["pipeline_eri"], "level": "INFO", "propagate": True}
 
     logging_dict["loggers"]["bamboo_engine"] = {
         "handlers": ["root", "bamboo_engine_context"],
         "level": "INFO",
-        "propagate": True,
+        "propagate": False,
     }
 
     logging_dict["loggers"]["pipeline_engine"] = {
         "handlers": ["root", "pipeline_engine_context"],
         "level": "INFO",
-        "propagate": True,
+        "propagate": False,
     }
 
     logging_dict["loggers"]["bk-monitor-report"] = {
@@ -370,8 +370,6 @@ def logging_addition_settings(logging_dict: dict, environment="prod"):
                 for handler in logger_config["handlers"]
                 if handler not in ["pipeline_engine_context", "bamboo_engine_context", "pipeline_eri"]
             ]
-            if not logger_config["handlers"]:
-                logger_config["handlers"] = ["root"]
 
     def handler_filter_injection(filters: list):
         for _, handler in logging_dict["handlers"].items():

--- a/tests/project_settings/test_logging_settings.py
+++ b/tests/project_settings/test_logging_settings.py
@@ -1,0 +1,99 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+BlueKing Flow Engine Service available.
+Copyright (C) 2024 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+
+to the current version of the project delivered to anyone in the future.
+"""
+
+from copy import deepcopy
+
+import pytest
+
+import env
+from config.default import logging_addition_settings
+
+BASE_LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {"format": "%(levelname)s %(message)s"},
+        "simple": {"format": "%(levelname)s %(message)s"},
+    },
+    "handlers": {
+        "root": {"class": "logging.StreamHandler", "formatter": "verbose"},
+        "component": {"class": "logging.StreamHandler", "formatter": "verbose"},
+    },
+    "loggers": {
+        "root": {"handlers": ["root"], "level": "INFO", "propagate": True},
+    },
+}
+
+
+def count_handler_calls(logging_config, logger_name, handler_name):
+    count = 0
+    current_name = logger_name
+
+    while current_name:
+        logger_config = logging_config["loggers"].get(current_name)
+        if logger_config:
+            count += logger_config["handlers"].count(handler_name)
+            if not logger_config.get("propagate", True):
+                break
+
+        current_name = current_name.rpartition(".")[0] or ("root" if current_name != "root" else "")
+
+    return count
+
+
+@pytest.mark.parametrize("data_source", ["DATABASE", "PaaS3"])
+@pytest.mark.parametrize(
+    "logger_name",
+    ["bamboo_engine", "pipeline_engine", "pipeline.logging", "pipeline.eri.log"],
+)
+def test_engine_log_is_written_to_root_handler_once(monkeypatch, data_source, logger_name):
+    monkeypatch.setattr(env, "NODE_LOG_DATA_SOURCE", data_source)
+    logging_config = deepcopy(BASE_LOGGING)
+
+    logging_addition_settings(logging_config)
+
+    assert count_handler_calls(logging_config, logger_name, "root") == 1
+
+
+def test_database_node_log_handlers_are_preserved(monkeypatch):
+    monkeypatch.setattr(env, "NODE_LOG_DATA_SOURCE", "DATABASE")
+    logging_config = deepcopy(BASE_LOGGING)
+
+    logging_addition_settings(logging_config)
+
+    assert count_handler_calls(logging_config, "bamboo_engine", "bamboo_engine_context") == 1
+    assert count_handler_calls(logging_config, "pipeline_engine", "pipeline_engine_context") == 1
+    assert count_handler_calls(logging_config, "pipeline.eri.log", "pipeline_eri") == 1
+
+
+@pytest.mark.parametrize(
+    "logger_name,handler_name",
+    [
+        ("bamboo_engine", "bamboo_engine_context"),
+        ("pipeline_engine", "pipeline_engine_context"),
+        ("pipeline.eri.log", "pipeline_eri"),
+    ],
+)
+def test_database_node_log_handlers_are_disabled_for_paas3(monkeypatch, logger_name, handler_name):
+    monkeypatch.setattr(env, "NODE_LOG_DATA_SOURCE", "PaaS3")
+    logging_config = deepcopy(BASE_LOGGING)
+
+    logging_addition_settings(logging_config)
+
+    assert count_handler_calls(logging_config, logger_name, handler_name) == 0


### PR DESCRIPTION
## 问题原因

`bamboo_engine`、`pipeline_engine` 和 `pipeline` 在自身绑定 `root` Handler 后仍向父 logger 传播，导致同一个 Handler 沿 logger 继承链被重复调用。PaaS3 日志模式下，`pipeline.eri.log` 的数据库 Handler 被移除后又补上 `root` Handler，最多会将同一条日志写入三次。

## 修改内容

- 将 `bamboo_engine`、`pipeline_engine` 和 `pipeline` 设为对应日志链路的传播终点。
- PaaS3 模式下允许 `pipeline.eri.log` 使用空 Handler 并传播到 `pipeline`，避免重复绑定 `root`。
- 增加 DATABASE/PaaS3 两种模式的日志路由回归测试。
- 确认数据库节点日志 Handler 在 DATABASE 模式下仍调用一次，在 PaaS3 模式下仍按原逻辑关闭。

## 影响范围

仅调整 Python logging Handler 的传播路径，不修改日志内容、级别、格式、Trace 信息、节点信息或日志查询接口。合法的重复业务日志不会被过滤。

## 验证

- `pytest tests/project_settings tests/engine/task/test_node_log.py -q --no-cov`：25 passed。
- `pre-commit run --files config/default.py tests/project_settings/test_logging_settings.py`：全部通过。
- 更大范围 engine 测试中，156 个无数据库依赖用例通过；其余 222 个因本机未启动 MySQL 而无法执行。