### PR TITLE
feat(debug): 支持条件网关单步调试

### DIFF
--- a/bkflow/apigw/docs/zh/sdk_debug_context.md
+++ b/bkflow/apigw/docs/zh/sdk_debug_context.md
@@ -51,8 +51,31 @@ GET /sdk/template/debug/context/?space_id=1&template_id=100
   "nodes": [
     {
       "node_id": "node1",
+      "node_type": "ServiceActivity",
+      "execution_mode": "real",
+      "supports_mock": true,
       "status": "waiting",
-      "waiting_reason": "callback"
+      "waiting_reason": "callback",
+      "selected_flow_ids": [],
+      "condition_results": []
+    },
+    {
+      "node_id": "gateway1",
+      "node_type": "ExclusiveGateway",
+      "execution_mode": "real",
+      "supports_mock": false,
+      "status": "finished",
+      "waiting_reason": null,
+      "selected_flow_ids": ["flow_true"],
+      "condition_results": [
+        {
+          "flow_id": "flow_true",
+          "name": "条件1",
+          "expression": "${count} > 0",
+          "resolved_expression": "1 > 0",
+          "matched": true
+        }
+      ]
     }
   ]
 }
@@ -61,3 +84,7 @@ GET /sdk/template/debug/context/?space_id=1&template_id=100
 `status` 表示上下文锁状态，取值为 `idle | running | terminating`。运行结果以 `last_run_status` 为准，取值为 `not_run | running | waiting | paused | finished | failed | revoked`。其中 `revoked` 仅表示全局调试被主动终止，前端展示为“调试终止”；单节点终止完成后为 `not_run`。
 
 `active_task_id` 仅在任务运行期间有值，任务结束后清空；`last_task_id` 会保留最近一次真实引擎任务 ID。节点 `status` 取值为 `not_run | running | waiting | paused | finished | failed`。全局调试终止时，仍活跃的节点会恢复为 `not_run`，已完成或自然失败节点保留原状态。存在引擎调度记录时，`waiting_reason` 为 `callback | multiple_callback | poll`。
+
+`nodes` 只包含活动节点、分支网关（`ExclusiveGateway`）和条件并行网关（`ConditionalParallelGateway`）。开始、结束、并行网关和汇聚网关不需要调试，因此不会出现在该数组中。
+
+条件网关固定为 `execution_mode=real` 且 `supports_mock=false`。网关调试完成后，前端直接使用 `selected_flow_ids` 将命中的连线标记为绿色；`condition_results` 可用于展示每个分支的原始表达式、求值后的表达式和命中结果。活动节点的这两个字段均为空数组。

--- a/bkflow/apigw/docs/zh/sdk_debug_node_mock.md
+++ b/bkflow/apigw/docs/zh/sdk_debug_node_mock.md
@@ -20,6 +20,8 @@
 | mock_outputs | dict | 否 | mock 输出 |
 | mock_error | string | 否 | mock 失败信息 |
 
+分支网关和条件并行网关不支持 Mock。对这两类节点调用本接口会返回“条件网关不支持 Mock”。
+
 ### 请求参数示例
 
 ```json

--- a/bkflow/apigw/docs/zh/sdk_debug_step_run.md
+++ b/bkflow/apigw/docs/zh/sdk_debug_step_run.md
@@ -15,7 +15,7 @@
 | space_id | int | 是 | 空间ID |
 | template_id | int | 是 | 流程模板ID |
 | node_id | string | 是 | 节点ID |
-| mode | string | 否 | 执行模式，`real` 或 `mock` |
+| mode | string | 否 | 执行模式，`real` 或 `mock`；条件网关仅支持 `real` |
 | input_overrides | dict | 否 | 输入覆盖参数 |
 | mock_result | string | 否 | mock 结果，`success` 或 `fail` |
 | mock_outputs | dict | 否 | mock 输出 |
@@ -54,3 +54,27 @@ real 单步创建并启动引擎任务后立即返回。调用方通过 `debug_c
 ```
 
 mock 模式仍同步返回 `finished` 或 `failed` 及对应输出、错误详情和更新后的全局变量。
+
+### 条件网关 real 模式返回结果示例
+
+分支网关和条件并行网关同步计算分支条件，只返回命中的连线，不创建引擎任务，也不会执行命中连线后的节点。前端使用 `selected_flow_ids` 将对应路径标记为绿色。
+
+```json
+{
+  "node_id": "gateway1",
+  "status": "finished",
+  "selected_flow_ids": ["flow_true"],
+  "condition_results": [
+    {
+      "flow_id": "flow_true",
+      "name": "条件1",
+      "expression": "${count} > 0",
+      "resolved_expression": "1 > 0",
+      "matched": true
+    }
+  ],
+  "error_detail": null
+}
+```
+
+条件网关依赖的前序节点输出尚不存在时，接口返回“依赖未满足”及 `missing_vars`。表达式解析失败、分支网关同时命中多个条件等执行错误会同步返回 `status=failed`，并将错误写入 `error_detail`；随后也可从 `debug_context.nodes[]` 获取相同状态和分支结果。

--- a/bkflow/template/debug/gateway.py
+++ b/bkflow/template/debug/gateway.py
@@ -1,0 +1,171 @@
+"""条件网关调试求值。"""
+
+import copy
+from typing import Any, Dict, List
+
+from bamboo_engine.template import Template
+from bamboo_engine.utils.boolrule import BoolRule
+from bamboo_engine.utils.constants import ExclusiveGatewayStrategy
+from bamboo_engine.utils.string import transform_escape_char
+from bkflow_feel.api import parse_expression
+
+from bkflow.utils.mako import parse_mako_expression
+
+DEBUGGABLE_GATEWAY_TYPES = {"ExclusiveGateway", "ConditionalParallelGateway"}
+
+
+class GatewayEvaluationError(Exception):
+    """网关条件无法完成求值。"""
+
+    def __init__(self, message: str, condition_results: List[dict] = None):
+        super().__init__(message)
+        self.condition_results = condition_results or []
+
+
+def _evaluate_expression(expression: str, context: dict, extra_info: dict) -> bool:
+    parse_lang = extra_info.get("parse_lang")
+    if parse_lang == "FEEL":
+        return parse_expression(expression=expression)
+    if parse_lang == "MAKO":
+        return parse_mako_expression(expression=expression, context=context)
+    return BoolRule(expression).test()
+
+
+def _deformat_key(key: str) -> str:
+    if isinstance(key, str) and key.startswith("${") and key.endswith("}"):
+        return key[2:-1]
+    return key
+
+
+def _has_value(values: dict, key: str) -> bool:
+    return key in values or _deformat_key(key) in values
+
+
+def _get_value(values: dict, key: str, default: Any = None) -> Any:
+    if key in values:
+        return values[key]
+    return values.get(_deformat_key(key), default)
+
+
+def _build_hydrated_context(pipeline_tree: dict, values: dict) -> Dict[str, Any]:
+    constants = pipeline_tree.get("constants", {})
+    context = {}
+    overridden_keys = set()
+    for key, constant in constants.items():
+        context[_deformat_key(key)] = _get_value(values, key, constant.get("value"))
+    for key, value in values.items():
+        raw_key = _deformat_key(key)
+        context[raw_key] = value
+        overridden_keys.add(raw_key)
+
+    # Context.hydrate 会递归展开常量引用；这里用有界迭代复现该行为，并保持显式调试值优先。
+    for _ in range(len(constants)):
+        changed = False
+        for key, constant in constants.items():
+            raw_key = _deformat_key(key)
+            if raw_key in overridden_keys:
+                continue
+            rendered = Template(copy.deepcopy(constant.get("value"))).render(context)
+            if rendered != context.get(raw_key):
+                context[raw_key] = rendered
+                changed = True
+        if not changed:
+            break
+    return {key: transform_escape_char(value) for key, value in context.items()}
+
+
+def _source_node_id(constant: dict):
+    source_info = constant.get("source_info") or {}
+    return next(iter(source_info), None) if isinstance(source_info, dict) else None
+
+
+def gateway_missing_vars(pipeline_tree: dict, gateway_id: str, values: dict) -> List[dict]:
+    """返回网关条件依赖但尚未由前序节点产出的变量。"""
+
+    gateway = pipeline_tree.get("gateways", {}).get(gateway_id) or {}
+    references = set()
+    for condition in gateway.get("conditions", {}).values():
+        references.update(Template(condition.get("evaluate", "")).get_reference())
+
+    constants = pipeline_tree.get("constants", {})
+    missing = {}
+    visited = set()
+    pending = list(references)
+    while pending:
+        key = pending.pop()
+        if key in visited:
+            continue
+        visited.add(key)
+        constant = constants.get(key) or {}
+        if _has_value(values, key):
+            continue
+        if constant.get("source_type") == "component_outputs":
+            missing[key] = {"key": key, "source_node_id": _source_node_id(constant)}
+            continue
+        pending.extend(Template(copy.deepcopy(constant.get("value"))).get_reference())
+    return [missing[key] for key in sorted(missing)]
+
+
+def _is_first_match_strategy(gateway: dict) -> bool:
+    strategy = (gateway.get("extra_info") or {}).get("strategy")
+    return strategy in {
+        ExclusiveGatewayStrategy.FIRST.name,
+        ExclusiveGatewayStrategy.FIRST.value,
+        str(ExclusiveGatewayStrategy.FIRST.value),
+    }
+
+
+def evaluate_gateway(pipeline_tree: dict, gateway_id: str, values: dict) -> dict:
+    """按引擎条件语义计算网关命中的连线，不执行后续节点。"""
+
+    gateway = pipeline_tree.get("gateways", {}).get(gateway_id)
+    if not gateway or gateway.get("type") not in DEBUGGABLE_GATEWAY_TYPES:
+        raise GatewayEvaluationError("节点不是可调试的条件网关")
+
+    missing_vars = gateway_missing_vars(pipeline_tree, gateway_id, values)
+    if missing_vars:
+        keys = ", ".join(item["key"] for item in missing_vars)
+        raise GatewayEvaluationError("网关条件依赖未满足：{}".format(keys))
+
+    context = _build_hydrated_context(pipeline_tree, values)
+    condition_results = []
+    selected_flow_ids = []
+    first_match = gateway.get("type") == "ExclusiveGateway" and _is_first_match_strategy(gateway)
+
+    for flow_id, condition in gateway.get("conditions", {}).items():
+        expression = condition.get("evaluate")
+        if not isinstance(expression, str) or not expression.strip():
+            raise GatewayEvaluationError("分支条件解析失败：条件表达式为空", condition_results)
+        try:
+            resolved_expression = Template(expression).render(context)
+            matched = bool(_evaluate_expression(resolved_expression, context, gateway.get("extra_info") or {}))
+        except Exception as error:
+            raise GatewayEvaluationError("分支条件解析失败：{}".format(error), condition_results) from error
+
+        condition_results.append(
+            {
+                "flow_id": flow_id,
+                "name": condition.get("name", ""),
+                "expression": expression,
+                "resolved_expression": resolved_expression,
+                "matched": matched,
+            }
+        )
+        if matched:
+            selected_flow_ids.append(flow_id)
+            if first_match:
+                break
+
+    default_flow_id = (gateway.get("default_condition") or {}).get("flow_id")
+    if not selected_flow_ids:
+        if not default_flow_id:
+            raise GatewayEvaluationError("所有分支条件均不满足，且未配置默认分支", condition_results)
+        selected_flow_ids.append(default_flow_id)
+
+    if gateway.get("type") == "ExclusiveGateway" and len(selected_flow_ids) > 1:
+        raise GatewayEvaluationError("多个分支条件同时满足", condition_results)
+
+    return {
+        "selected_flow_ids": selected_flow_ids,
+        "condition_results": condition_results,
+    }

--- a/bkflow/template/debug/service.py
+++ b/bkflow/template/debug/service.py
@@ -20,6 +20,7 @@ to the current version of the project delivered to anyone in the future.
 import copy
 import datetime
 import logging
+import time
 
 from django.conf import settings
 from django.db import transaction
@@ -31,6 +32,12 @@ from bkflow.template.debug.dependency import (
     build_dependency_graph,
     closure,
     compute_tree_fingerprint,
+)
+from bkflow.template.debug.gateway import (
+    DEBUGGABLE_GATEWAY_TYPES,
+    GatewayEvaluationError,
+    evaluate_gateway,
+    gateway_missing_vars,
 )
 from bkflow.template.models import (
     DebugContext,
@@ -98,22 +105,40 @@ class DebugService:
         """按当前 pipeline_tree 增删 DebugNodeState；保留已存在节点的配置与运行态。"""
         ctx = self.get_or_create_context()
         activities = self.pipeline_tree.get("activities", {})
+        gateways = {
+            node_id: gateway
+            for node_id, gateway in self.pipeline_tree.get("gateways", {}).items()
+            if gateway.get("type") in DEBUGGABLE_GATEWAY_TYPES
+        }
+        debug_nodes = {**activities, **gateways}
         existing = {ns.node_id: ns for ns in DebugNodeState.objects.filter(debug_context=ctx)}
-        tree_node_ids = set(activities.keys())
+        tree_node_ids = set(debug_nodes)
 
-        new_node_ids = [node_id for node_id in activities if node_id not in existing]
+        new_node_ids = [node_id for node_id in debug_nodes if node_id not in existing]
         to_create = [
             DebugNodeState(
                 debug_context=ctx,
                 node_id=node_id,
-                node_type=activities[node_id].get("type", "ServiceActivity"),
+                node_type=debug_nodes[node_id].get("type", "ServiceActivity"),
             )
             for node_id in new_node_ids
         ]
         if to_create:
             # 并发安全：ignore_conflicts 保证并发 sync 不会因唯一键冲突报错
             DebugNodeState.objects.bulk_create(to_create, ignore_conflicts=True)
-            self._apply_legacy_mock_scheme(ctx, new_node_ids)
+            self._apply_legacy_mock_scheme(ctx, [node_id for node_id in new_node_ids if node_id in activities])
+        to_update = []
+        for node_id, ns in existing.items():
+            expected_type = (debug_nodes.get(node_id) or {}).get("type", "ServiceActivity")
+            if node_id in debug_nodes and ns.node_type != expected_type:
+                ns.node_type = expected_type
+                to_update.append(ns)
+        if to_update:
+            DebugNodeState.objects.bulk_update(to_update, ["node_type"])
+        if gateways:
+            DebugNodeState.objects.filter(debug_context=ctx, node_id__in=gateways).exclude(
+                execution_mode="real"
+            ).update(execution_mode="real")
         stale = set(existing.keys()) - tree_node_ids
         if stale:
             DebugNodeState.objects.filter(debug_context=ctx, node_id__in=stale).delete()
@@ -158,6 +183,10 @@ class DebugService:
             )
         return fields
 
+    def _is_debuggable_gateway(self, node_id):
+        gateway = self.pipeline_tree.get("gateways", {}).get(node_id) or {}
+        return gateway.get("type") in DEBUGGABLE_GATEWAY_TYPES
+
     def build_context_view(self) -> dict:
         ctx = self.sync_node_states()
         self.sync_from_debug_task(ctx)
@@ -165,16 +194,25 @@ class DebugService:
         node_views = []
         for ns in DebugNodeState.objects.filter(debug_context=ctx).order_by("node_id"):
             can_step, missing = self.compute_can_step(ctx, ns.node_id)
+            is_gateway = self._is_debuggable_gateway(ns.node_id)
+            gateway_result = (ns.outputs or {}) if is_gateway else {}
             node_views.append(
                 {
                     "node_id": ns.node_id,
                     "node_type": ns.node_type,
-                    "execution_mode": ns.execution_mode,
-                    "mock_result": ns.mock_result if ns.execution_mode == "mock" else None,
+                    "execution_mode": "real" if is_gateway else ns.execution_mode,
+                    "supports_mock": not is_gateway,
+                    "mock_result": ns.mock_result if not is_gateway and ns.execution_mode == "mock" else None,
                     "mock_outputs": (
-                        ns.mock_outputs if ns.execution_mode == "mock" and ns.mock_result == "success" else None
+                        ns.mock_outputs
+                        if not is_gateway and ns.execution_mode == "mock" and ns.mock_result == "success"
+                        else None
                     ),
-                    "mock_error": ns.mock_error if ns.execution_mode == "mock" and ns.mock_result == "fail" else None,
+                    "mock_error": (
+                        ns.mock_error
+                        if not is_gateway and ns.execution_mode == "mock" and ns.mock_result == "fail"
+                        else None
+                    ),
                     "status": ns.status,
                     "waiting_reason": ns.waiting_reason or None,
                     "can_step": can_step,
@@ -182,6 +220,8 @@ class DebugService:
                     "duration_ms": ns.duration_ms,
                     "error_detail": ns.error_detail or None,
                     "log_ref": ns.log_ref or None,
+                    "selected_flow_ids": gateway_result.get("selected_flow_ids", []),
+                    "condition_results": gateway_result.get("condition_results", []),
                 }
             )
         return {
@@ -202,6 +242,9 @@ class DebugService:
 
     def compute_can_step(self, ctx, node_id):
         """判定节点是否可单步：引用的产出型变量须已在 global_vars 有值，否则返回缺失项。"""
+        if self._is_debuggable_gateway(node_id):
+            missing = gateway_missing_vars(self.pipeline_tree, node_id, ctx.global_vars or {})
+            return (len(missing) == 0), missing
         act = self.pipeline_tree.get("activities", {}).get(node_id)
         if not act:
             return False, []
@@ -567,7 +610,22 @@ class DebugService:
                 ns.log_ref = {"instance_id": task_id, "node_id": runtime_id, "version": version}
                 outputs = {o["key"]: o["value"] for o in ddata.get("outputs", []) if isinstance(o, dict) and "key" in o}
                 if ns.status == "finished":
-                    ns.outputs = outputs
+                    if self._is_debuggable_gateway(tpl_node_id):
+                        try:
+                            ns.outputs = evaluate_gateway(self.pipeline_tree, tpl_node_id, ctx.global_vars or {})
+                        except GatewayEvaluationError as error:
+                            logger.warning(
+                                "[debug] sync gateway selected flows failed, template_id=%s, node_id=%s, error=%s",
+                                self.template_id,
+                                tpl_node_id,
+                                error,
+                            )
+                            ns.outputs = {
+                                "selected_flow_ids": [],
+                                "condition_results": error.condition_results,
+                            }
+                    else:
+                        ns.outputs = outputs
                     ns.error_detail = {}
                     for out_key, var_key in acts_outputs.get(tpl_node_id, {}).items():
                         if out_key in outputs:
@@ -575,7 +633,17 @@ class DebugService:
                 else:
                     message = ddata.get("ex_data") or "step failed"
                     runtime_errors[runtime_id] = message
-                    ns.outputs = {}
+                    if self._is_debuggable_gateway(tpl_node_id):
+                        try:
+                            gateway_result = evaluate_gateway(self.pipeline_tree, tpl_node_id, ctx.global_vars or {})
+                            ns.outputs = gateway_result
+                        except GatewayEvaluationError as error:
+                            ns.outputs = {
+                                "selected_flow_ids": [],
+                                "condition_results": error.condition_results,
+                            }
+                    else:
+                        ns.outputs = {}
                     ns.error_detail = {"type": "runtime", "message": message}
             ns.save()
 
@@ -804,6 +872,8 @@ class DebugService:
             ns = DebugNodeState.objects.get(debug_context=ctx, node_id=node_id)
         except DebugNodeState.DoesNotExist:
             raise DebugStateError({"detail": "节点不存在", "node_id": node_id})
+        if self._is_debuggable_gateway(node_id):
+            raise DebugStateError("条件网关不支持 Mock")
         if enable:
             ns.execution_mode = "mock"
             ns.mock_result = mock_result
@@ -844,9 +914,70 @@ class DebugService:
             raise DebugStateError({"detail": "节点不存在", "node_id": node_id})
         effective_mode = mode or ns.execution_mode
 
+        if self._is_debuggable_gateway(node_id):
+            if effective_mode == "mock":
+                raise DebugStateError("条件网关不支持 Mock")
+            return self._step_run_gateway(ctx, ns, operator, input_overrides)
         if effective_mode == "mock":
             return self._step_run_mock(ctx, ns, mock_result, mock_outputs, mock_error)
         return self._step_run_real(ctx, ns, operator, input_overrides)
+
+    def _step_run_gateway(self, ctx, ns, operator, input_overrides):
+        values = dict(ctx.global_vars or {}) if input_overrides is None else dict(input_overrides)
+        missing = gateway_missing_vars(self.pipeline_tree, ns.node_id, values)
+        if missing:
+            raise DebugStateError({"detail": "依赖未满足", "missing_vars": missing})
+
+        self._acquire_lock(ctx, operator)
+        started_at = time.monotonic()
+        try:
+            ns.execution_mode = "real"
+            ns.status = "running"
+            ns.waiting_reason = ""
+            ns.outputs = {}
+            ns.error_detail = {}
+            ns.log_ref = {}
+            ns.last_run_at = timezone.now()
+            ns.save()
+            try:
+                result = evaluate_gateway(self.pipeline_tree, ns.node_id, values)
+                ns.status = "finished"
+                ns.outputs = result
+                ns.error_detail = {}
+                ctx.last_run_status = "finished"
+                ctx.last_error_detail = {}
+                response = {
+                    "node_id": ns.node_id,
+                    "status": "finished",
+                    "selected_flow_ids": result["selected_flow_ids"],
+                    "condition_results": result["condition_results"],
+                    "error_detail": None,
+                }
+            except GatewayEvaluationError as error:
+                detail = {"type": "gateway", "message": str(error)}
+                ns.status = "failed"
+                ns.outputs = {
+                    "selected_flow_ids": [],
+                    "condition_results": error.condition_results,
+                }
+                ns.error_detail = detail
+                ctx.last_run_status = "failed"
+                ctx.last_error_detail = detail
+                response = {
+                    "node_id": ns.node_id,
+                    "status": "failed",
+                    "selected_flow_ids": [],
+                    "condition_results": error.condition_results,
+                    "error_detail": detail,
+                }
+
+            ns.duration_ms = int((time.monotonic() - started_at) * 1000)
+            ns.save()
+            ctx.last_run_type = "step"
+            ctx.save(update_fields=["last_run_type", "last_run_status", "last_error_detail"])
+            return response
+        finally:
+            self._release_lock(ctx, status="idle")
 
     def _step_run_mock(self, ctx, ns, mock_result, mock_outputs, mock_error):
         ns.log_ref = {}

--- a/docs/superpowers/plans/2026-08-06-debuggable-condition-gateways.md
+++ b/docs/superpowers/plans/2026-08-06-debuggable-condition-gateways.md
@@ -136,4 +136,3 @@ Run: `PYENV_VERSION=3.10.6 black --check bkflow/template/debug tests/interface/t
 Run: `PYENV_VERSION=3.10.6 flake8 bkflow/template/debug tests/interface/template/debug`
 
 Expected: both commands exit 0.
-

--- a/docs/superpowers/plans/2026-08-06-debuggable-condition-gateways.md
+++ b/docs/superpowers/plans/2026-08-06-debuggable-condition-gateways.md
@@ -1,0 +1,139 @@
+# Debuggable Conditional Gateways Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add persistent debug status and synchronous path evaluation for conditional gateways while removing non-debuggable control nodes from the debug panel.
+
+**Architecture:** A focused gateway evaluator renders conditions with the same template and expression functions used by the engine. `DebugService` includes only activity nodes plus condition-bearing gateways in `DebugNodeState`, dispatches gateway step calls to the synchronous evaluator, and stores selected paths in the existing `outputs` JSON field.
+
+**Tech Stack:** Python 3.10, Django, Django REST Framework, bamboo-pipeline 3.29.9, pytest.
+
+## Global Constraints
+
+- Gateway single-step evaluation must not create an engine task or execute downstream nodes.
+- Only `ExclusiveGateway` and `ConditionalParallelGateway` are debuggable gateways.
+- Gateways always use real mode and never support mock.
+- Start, end, parallel, and converge control nodes must not appear in `debug_context.nodes`.
+- Do not add a database migration; persist branch results in `DebugNodeState.outputs`.
+
+---
+
+### Task 1: Gateway Evaluation Unit
+
+**Files:**
+- Create: `bkflow/template/debug/gateway.py`
+- Create: `tests/interface/template/debug/test_gateway.py`
+
+**Interfaces:**
+- Produces: `DEBUGGABLE_GATEWAY_TYPES`, `GatewayEvaluationError`, `gateway_missing_vars(pipeline_tree, gateway_id, values)`, and `evaluate_gateway(pipeline_tree, gateway_id, values)`.
+- `evaluate_gateway` returns `{"selected_flow_ids": list[str], "condition_results": list[dict]}`.
+
+- [ ] **Step 1: Write failing evaluator tests**
+
+Cover exclusive single selection, exclusive default selection, exclusive multiple-match failure, conditional-parallel multi-selection, missing produced variables, and malformed expressions.
+
+- [ ] **Step 2: Run the evaluator tests and verify they fail**
+
+Run: `PYENV_VERSION=3.10.6 pytest tests/interface/template/debug/test_gateway.py -q`
+
+Expected: collection fails because `bkflow.template.debug.gateway` does not exist.
+
+- [ ] **Step 3: Implement the gateway evaluator**
+
+Render condition expressions using `bamboo_engine.template.Template`, evaluate them using `bkflow.utils.pipeline.pipeline_gateway_expr_func`, preserve flow IDs, and raise `GatewayEvaluationError` with user-facing details for invalid selection.
+
+- [ ] **Step 4: Run evaluator tests**
+
+Run: `PYENV_VERSION=3.10.6 pytest tests/interface/template/debug/test_gateway.py -q`
+
+Expected: all evaluator tests pass.
+
+### Task 2: Context Node Selection And Capabilities
+
+**Files:**
+- Modify: `bkflow/template/debug/service.py`
+- Modify: `tests/interface/template/debug/test_service_context.py`
+
+**Interfaces:**
+- `sync_node_states()` creates states for activities plus gateways whose type is in `DEBUGGABLE_GATEWAY_TYPES`.
+- `build_context_view()` returns `supports_mock`, `selected_flow_ids`, and `condition_results`.
+- `compute_can_step()` supports condition expressions as well as activity inputs.
+
+- [ ] **Step 1: Add failing context tests**
+
+Build a tree containing an activity, both conditional gateways, a parallel gateway, and a converge gateway. Assert that context contains only the activity and two conditional gateways, and that gateway capability/result fields have the documented values.
+
+- [ ] **Step 2: Run context tests and verify failure**
+
+Run: `PYENV_VERSION=3.10.6 pytest tests/interface/template/debug/test_service_context.py -q`
+
+- [ ] **Step 3: Implement node selection and response fields**
+
+Build a merged debug-node mapping, restrict legacy mock initialization to activities, and map gateway `outputs` to the explicit branch-result fields.
+
+- [ ] **Step 4: Run context tests**
+
+Run: `PYENV_VERSION=3.10.6 pytest tests/interface/template/debug/test_service_context.py -q`
+
+Expected: all context tests pass.
+
+### Task 3: Gateway Step Execution And Global Synchronization
+
+**Files:**
+- Modify: `bkflow/template/debug/service.py`
+- Modify: `tests/interface/template/debug/test_step_run.py`
+- Modify: `tests/interface/template/debug/test_service_sync.py`
+- Modify: `tests/interface/template/debug/test_views_run_ops.py`
+
+**Interfaces:**
+- `step_run()` dispatches debuggable gateways to `_step_run_gateway()`.
+- `_step_run_gateway()` synchronously persists `finished` or `failed` and returns branch results without a task ID.
+- `node_mock()` and `step_run(mode="mock")` reject gateways.
+- `sync_from_debug_task()` persists gateway runtime state and branch results during global runs.
+
+- [ ] **Step 1: Add failing service and view tests**
+
+Assert synchronous successful gateway steps, failed expression state, mock rejection, lock release, no task-client calls, and successful/failed global gateway synchronization.
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Run: `PYENV_VERSION=3.10.6 pytest tests/interface/template/debug/test_step_run.py tests/interface/template/debug/test_service_sync.py tests/interface/template/debug/test_views_run_ops.py -q`
+
+- [ ] **Step 3: Implement gateway step and synchronization**
+
+Acquire/release the existing debug lock around direct evaluation, persist results in `outputs`, update context last-run fields, and reuse the evaluator after a globally executed gateway reaches `FINISHED`.
+
+- [ ] **Step 4: Run focused tests**
+
+Run: `PYENV_VERSION=3.10.6 pytest tests/interface/template/debug/test_step_run.py tests/interface/template/debug/test_service_sync.py tests/interface/template/debug/test_views_run_ops.py -q`
+
+Expected: all focused tests pass.
+
+### Task 4: Contract Documentation And Regression
+
+**Files:**
+- Modify: `bkflow/apigw/docs/zh/sdk_debug_context.md`
+- Modify: `bkflow/apigw/docs/zh/sdk_debug_step_run.md`
+- Modify: `bkflow/apigw/docs/zh/sdk_debug_node_mock.md`
+
+**Interfaces:**
+- Documents capability fields, selected flow IDs, synchronous gateway step responses, and gateway mock rejection.
+
+- [ ] **Step 1: Update API examples and field descriptions**
+
+Document both activity and gateway nodes without changing route names.
+
+- [ ] **Step 2: Run the complete debug test suite**
+
+Run: `PYENV_VERSION=3.10.6 pytest tests/interface/template/debug -q`
+
+Expected: all debug tests pass.
+
+- [ ] **Step 3: Run formatting and static checks on changed Python files**
+
+Run: `PYENV_VERSION=3.10.6 black --check bkflow/template/debug tests/interface/template/debug`
+
+Run: `PYENV_VERSION=3.10.6 flake8 bkflow/template/debug tests/interface/template/debug`
+
+Expected: both commands exit 0.
+

--- a/docs/superpowers/specs/2026-08-06-debuggable-condition-gateways-design.md
+++ b/docs/superpowers/specs/2026-08-06-debuggable-condition-gateways-design.md
@@ -97,4 +97,3 @@ During a real global debug run, gateway runtime IDs already appear in `get_node_
 - Unit tests cover boolrule selection, default branches, conditional parallel multi-selection, missing variables, malformed expressions, and exclusive multiple-match failure.
 - Service tests verify synchronous gateway step state, mock rejection, lock release, reset behavior, and global-run gateway state synchronization.
 - View tests verify standard response wrapping and HTTP 400 errors.
-

--- a/docs/superpowers/specs/2026-08-06-debuggable-condition-gateways-design.md
+++ b/docs/superpowers/specs/2026-08-06-debuggable-condition-gateways-design.md
@@ -1,0 +1,100 @@
+# BKFlow Conditional Gateway Debugging Design
+
+## Goal
+
+Expose only nodes that have meaningful debug behavior, and make condition-bearing gateways independently debuggable without executing downstream nodes.
+
+## Scope
+
+- Keep activity nodes in the debug control panel.
+- Add `ExclusiveGateway` and `ConditionalParallelGateway` to `debug_context.nodes`.
+- Keep start events, end events, `ParallelGateway`, and `ConvergeGateway` out of `debug_context.nodes`.
+- Allow real single-step evaluation for condition-bearing gateways.
+- Do not support mock mode for gateways.
+- Persist gateway status and selected outgoing flow IDs so callers can highlight the selected paths.
+
+## API Contract
+
+Gateway entries in `debug_context.data.nodes[]` use the existing node status fields and add explicit capabilities and branch results:
+
+```json
+{
+  "node_id": "gateway1",
+  "node_type": "ExclusiveGateway",
+  "execution_mode": "real",
+  "supports_mock": false,
+  "status": "finished",
+  "can_step": true,
+  "missing_vars": [],
+  "selected_flow_ids": ["flow_true"],
+  "condition_results": [
+    {
+      "flow_id": "flow_true",
+      "name": "condition 1",
+      "expression": "${count} > 0",
+      "resolved_expression": "1 > 0",
+      "matched": true
+    }
+  ],
+  "error_detail": null,
+  "duration_ms": 1,
+  "log_ref": null
+}
+```
+
+Activity entries add `supports_mock: true` and return empty gateway result fields. This lets callers render capabilities without hard-coding node types.
+
+`debug_step_run` accepts a condition gateway `node_id`. Gateway execution is synchronous and returns:
+
+```json
+{
+  "node_id": "gateway1",
+  "status": "finished",
+  "selected_flow_ids": ["flow_true"],
+  "condition_results": []
+}
+```
+
+`debug_step_run` with `mode=mock`, and every `debug_node_mock` call for a gateway, return HTTP 400 with a clear message that gateways do not support mock.
+
+## Evaluation Semantics
+
+Gateway single-step evaluation does not create a task and does not execute any downstream node. It evaluates conditions from the current template draft using the current `DebugContext.global_vars`, with template constant defaults as fallback values.
+
+- Expressions are rendered with bamboo-engine `Template` and evaluated with BKFlow's `pipeline_gateway_expr_func`, preserving boolrule, FEEL, and MAKO selection.
+- `ExclusiveGateway` follows the configured strategy. The normal strategy requires exactly one matching condition; the first-match strategy stops at the first match.
+- `ConditionalParallelGateway` selects every matching condition.
+- If no condition matches, the configured default flow is selected.
+- Missing produced variables, malformed expressions, no matching/default branch, and multiple matches in an exclusive gateway produce `status=failed` with `error_detail`.
+
+The operation briefly acquires the template debug lock and releases it before returning. This prevents overlap with global or activity-node debugging while keeping gateway evaluation synchronous.
+
+## Persistence And Global Runs
+
+No migration is required. Gateway branch results are stored in the existing `DebugNodeState.outputs` JSON field:
+
+```json
+{
+  "selected_flow_ids": ["flow_true"],
+  "condition_results": []
+}
+```
+
+`reset` clears these values through the existing result reset path.
+
+During a real global debug run, gateway runtime IDs already appear in `get_node_id_map`. Once gateway states are included in `DebugNodeState`, the existing synchronization loop writes `running`, `finished`, or `failed` to the gateway. For a finished gateway, BKFlow calculates and stores the branch result from the synchronized debug context; for a failed gateway, it persists the engine node error in `error_detail` and the task-level failure remains in `last_error_detail`.
+
+## Compatibility
+
+- Existing activity node fields and behavior remain unchanged.
+- Existing SDK methods remain valid because `debug_step_run` already accepts an arbitrary node ID and SDK responses are untyped dictionaries.
+- Consumers that ignore the new fields continue to work.
+- Legacy mock schemes apply only to activity nodes; gateways always remain in real mode.
+
+## Verification
+
+- Context tests verify that only activities and the two condition gateway types are returned.
+- Unit tests cover boolrule selection, default branches, conditional parallel multi-selection, missing variables, malformed expressions, and exclusive multiple-match failure.
+- Service tests verify synchronous gateway step state, mock rejection, lock release, reset behavior, and global-run gateway state synchronization.
+- View tests verify standard response wrapping and HTTP 400 errors.
+

--- a/tests/interface/template/debug/test_gateway.py
+++ b/tests/interface/template/debug/test_gateway.py
@@ -1,0 +1,155 @@
+"""条件网关单步求值测试。"""
+
+import copy
+
+import pytest
+
+from bkflow.template.debug.gateway import (
+    GatewayEvaluationError,
+    evaluate_gateway,
+    gateway_missing_vars,
+)
+
+
+def _constant(key, value, source_type="custom", source_info=None):
+    return {
+        "key": key,
+        "name": key,
+        "value": value,
+        "source_type": source_type,
+        "source_info": source_info or {},
+        "source_tag": "",
+        "show_type": "hide",
+    }
+
+
+def _gateway_tree(gateway_type="ExclusiveGateway"):
+    return {
+        "activities": {
+            "producer": {
+                "id": "producer",
+                "type": "ServiceActivity",
+                "component": {"code": "test", "data": {}},
+            },
+            "positive": {"id": "positive", "type": "ServiceActivity"},
+            "negative": {"id": "negative", "type": "ServiceActivity"},
+            "fallback": {"id": "fallback", "type": "ServiceActivity"},
+        },
+        "gateways": {
+            "gateway": {
+                "id": "gateway",
+                "type": gateway_type,
+                "incoming": "flow_in",
+                "outgoing": ["flow_positive", "flow_negative", "flow_default"],
+                "conditions": {
+                    "flow_positive": {"name": "positive", "evaluate": "${count} > 0"},
+                    "flow_negative": {"name": "negative", "evaluate": "${count} < 0"},
+                },
+                "default_condition": {"name": "default", "flow_id": "flow_default"},
+                "extra_info": {"parse_lang": "boolrule"},
+            }
+        },
+        "flows": {
+            "flow_positive": {"id": "flow_positive", "source": "gateway", "target": "positive"},
+            "flow_negative": {"id": "flow_negative", "source": "gateway", "target": "negative"},
+            "flow_default": {"id": "flow_default", "source": "gateway", "target": "fallback"},
+        },
+        "constants": {
+            "${count}": _constant("${count}", 0),
+            "${produced}": _constant(
+                "${produced}",
+                "",
+                source_type="component_outputs",
+                source_info={"producer": ["value"]},
+            ),
+        },
+    }
+
+
+def test_evaluate_exclusive_gateway_selects_matching_flow():
+    result = evaluate_gateway(_gateway_tree(), "gateway", {"${count}": 1})
+
+    assert result["selected_flow_ids"] == ["flow_positive"]
+    assert result["condition_results"] == [
+        {
+            "flow_id": "flow_positive",
+            "name": "positive",
+            "expression": "${count} > 0",
+            "resolved_expression": "1 > 0",
+            "matched": True,
+        },
+        {
+            "flow_id": "flow_negative",
+            "name": "negative",
+            "expression": "${count} < 0",
+            "resolved_expression": "1 < 0",
+            "matched": False,
+        },
+    ]
+
+
+def test_evaluate_exclusive_gateway_uses_default_flow():
+    result = evaluate_gateway(_gateway_tree(), "gateway", {"${count}": 0})
+
+    assert result["selected_flow_ids"] == ["flow_default"]
+    assert [item["matched"] for item in result["condition_results"]] == [False, False]
+
+
+def test_evaluate_exclusive_gateway_rejects_multiple_matches():
+    tree = _gateway_tree()
+    tree["gateways"]["gateway"]["conditions"] = {
+        "flow_positive": {"name": "first", "evaluate": "1 == 1"},
+        "flow_negative": {"name": "second", "evaluate": "2 == 2"},
+    }
+
+    with pytest.raises(GatewayEvaluationError, match="多个分支条件同时满足"):
+        evaluate_gateway(tree, "gateway", {})
+
+
+def test_evaluate_conditional_parallel_gateway_selects_all_matching_flows():
+    tree = _gateway_tree("ConditionalParallelGateway")
+    tree["gateways"]["gateway"]["conditions"] = {
+        "flow_positive": {"name": "first", "evaluate": "${count} >= 1"},
+        "flow_negative": {"name": "second", "evaluate": "${count} <= 1"},
+    }
+
+    result = evaluate_gateway(tree, "gateway", {"${count}": 1})
+
+    assert result["selected_flow_ids"] == ["flow_positive", "flow_negative"]
+    assert [item["matched"] for item in result["condition_results"]] == [True, True]
+
+
+def test_gateway_missing_vars_reports_unavailable_produced_constant():
+    tree = _gateway_tree()
+    tree["gateways"]["gateway"]["conditions"]["flow_positive"]["evaluate"] = "${produced} == 1"
+
+    assert gateway_missing_vars(tree, "gateway", {}) == [{"key": "${produced}", "source_node_id": "producer"}]
+    assert gateway_missing_vars(tree, "gateway", {"${produced}": 1}) == []
+
+
+def test_gateway_missing_vars_follows_constant_references():
+    tree = _gateway_tree()
+    tree["constants"]["${alias}"] = _constant("${alias}", "${produced}")
+    tree["gateways"]["gateway"]["conditions"]["flow_positive"]["evaluate"] = "${alias} == 1"
+
+    assert gateway_missing_vars(tree, "gateway", {}) == [{"key": "${produced}", "source_node_id": "producer"}]
+    assert gateway_missing_vars(tree, "gateway", {"${produced}": 1}) == []
+
+
+def test_evaluate_gateway_resolves_referenced_constants():
+    tree = _gateway_tree()
+    tree["constants"]["${alias}"] = _constant("${alias}", "${count}")
+    tree["gateways"]["gateway"]["conditions"]["flow_positive"]["evaluate"] = "${alias} > 0"
+
+    result = evaluate_gateway(tree, "gateway", {"${count}": 1})
+
+    assert result["selected_flow_ids"] == ["flow_positive"]
+    assert result["condition_results"][0]["resolved_expression"] == "1 > 0"
+
+
+def test_evaluate_gateway_wraps_invalid_expression():
+    tree = copy.deepcopy(_gateway_tree())
+    tree["gateways"]["gateway"]["conditions"]["flow_positive"]["evaluate"] = ""
+
+    with pytest.raises(GatewayEvaluationError, match="分支条件解析失败"):
+        evaluate_gateway(tree, "gateway", {"${count}": 1})

--- a/tests/interface/template/debug/test_service_context.py
+++ b/tests/interface/template/debug/test_service_context.py
@@ -47,6 +47,43 @@ PIPELINE = {
     },
 }
 
+GATEWAY_PIPELINE = {
+    "activities": {
+        "A": {"id": "A", "type": "ServiceActivity", "component": {"code": "t", "data": {}}},
+    },
+    "flows": {},
+    "gateways": {
+        "EG": {
+            "id": "EG",
+            "type": "ExclusiveGateway",
+            "conditions": {"flow_positive": {"name": "positive", "evaluate": "${count} > 0"}},
+            "default_condition": {"flow_id": "flow_default"},
+            "extra_info": {"parse_lang": "boolrule"},
+        },
+        "CPG": {
+            "id": "CPG",
+            "type": "ConditionalParallelGateway",
+            "conditions": {"flow_positive": {"name": "positive", "evaluate": "${count} > 0"}},
+            "default_condition": {"flow_id": "flow_default"},
+            "extra_info": {"parse_lang": "boolrule"},
+        },
+        "PG": {"id": "PG", "type": "ParallelGateway"},
+        "CG": {"id": "CG", "type": "ConvergeGateway"},
+    },
+    "constants": {
+        "${count}": {
+            "key": "${count}",
+            "name": "count",
+            "show_type": "hide",
+            "value": 1,
+            "source_type": "custom",
+            "source_info": {},
+            "custom_type": "int",
+            "source_tag": "",
+        }
+    },
+}
+
 
 @pytest.mark.django_db
 class TestDebugServiceContext:
@@ -82,6 +119,28 @@ class TestDebugServiceContext:
         svc.sync_node_states()
         assert DebugNodeState.objects.get(debug_context=ctx, node_id="A").node_type == "ServiceActivity"
 
+    def test_sync_node_states_repairs_changed_node_type(self):
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=GATEWAY_PIPELINE)
+        ctx = svc.get_or_create_context()
+        DebugNodeState.objects.create(debug_context=ctx, node_id="EG", node_type="ServiceActivity")
+
+        svc.sync_node_states()
+
+        assert DebugNodeState.objects.get(debug_context=ctx, node_id="EG").node_type == "ExclusiveGateway"
+
+    def test_sync_node_states_includes_only_debuggable_gateways(self):
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=GATEWAY_PIPELINE)
+        ctx = svc.sync_node_states()
+
+        states = {
+            node_id: node_type
+            for node_id, node_type in DebugNodeState.objects.filter(debug_context=ctx).values_list(
+                "node_id", "node_type"
+            )
+        }
+
+        assert states == {"A": "ServiceActivity", "EG": "ExclusiveGateway", "CPG": "ConditionalParallelGateway"}
+
     def test_input_schema_excludes_hidden(self):
         tree = {
             "activities": {},
@@ -100,16 +159,47 @@ class TestDebugServiceContext:
         assert [n["node_id"] for n in view["nodes"]] == ["A", "B"]  # 按 node_id 排序
         node_a = view["nodes"][0]
         assert node_a["execution_mode"] == "real"
+        assert node_a["supports_mock"] is True
         assert node_a["mock_result"] is None  # real 模式不返回 mock_result
         assert node_a["mock_outputs"] is None
         assert node_a["status"] == "not_run"
         assert node_a["can_step"] is True  # Phase 3 前的占位
         assert node_a["log_ref"] is None and node_a["error_detail"] is None
         assert node_a["waiting_reason"] is None
+        assert node_a["selected_flow_ids"] == []
+        assert node_a["condition_results"] == []
         assert view["last_task_id"] is None
         assert view["last_run_type"] is None
         assert view["last_run_status"] == "not_run"
         assert view["last_error_detail"] is None
+
+    def test_build_context_view_returns_gateway_capabilities_and_state(self):
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=GATEWAY_PIPELINE)
+        ctx = svc.sync_node_states()
+        DebugNodeState.objects.filter(debug_context=ctx, node_id="EG").update(
+            execution_mode="mock",
+            status="finished",
+            outputs={
+                "selected_flow_ids": ["flow_positive"],
+                "condition_results": [
+                    {
+                        "flow_id": "flow_positive",
+                        "name": "positive",
+                        "expression": "${count} > 0",
+                        "resolved_expression": "1 > 0",
+                        "matched": True,
+                    }
+                ],
+            },
+        )
+
+        gateway = next(node for node in svc.build_context_view()["nodes"] if node["node_id"] == "EG")
+
+        assert gateway["execution_mode"] == "real"
+        assert gateway["supports_mock"] is False
+        assert gateway["mock_result"] is None
+        assert gateway["selected_flow_ids"] == ["flow_positive"]
+        assert gateway["condition_results"][0]["matched"] is True
 
     def test_build_context_view_returns_mock_outputs_for_success_preset(self):
         """mock 成功预设刷新后应能回填保存的输出"""

--- a/tests/interface/template/debug/test_service_sync.py
+++ b/tests/interface/template/debug/test_service_sync.py
@@ -40,6 +40,35 @@ PIPELINE = {
     },
 }
 
+PIPELINE_GATEWAY = {
+    "activities": {},
+    "flows": {
+        "flow_positive": {"id": "flow_positive", "source": "G", "target": "positive"},
+        "flow_default": {"id": "flow_default", "source": "G", "target": "fallback"},
+    },
+    "gateways": {
+        "G": {
+            "id": "G",
+            "type": "ExclusiveGateway",
+            "conditions": {"flow_positive": {"name": "positive", "evaluate": "${count} > 0"}},
+            "default_condition": {"flow_id": "flow_default"},
+            "extra_info": {"parse_lang": "boolrule"},
+        }
+    },
+    "constants": {
+        "${count}": {
+            "key": "${count}",
+            "name": "count",
+            "show_type": "hide",
+            "value": 0,
+            "source_type": "custom",
+            "custom_type": "int",
+            "source_tag": "",
+            "source_info": {},
+        }
+    },
+}
+
 
 @pytest.mark.django_db
 class TestSyncFromDebugTask:
@@ -268,7 +297,7 @@ class TestSyncFromDebugTask:
         task_client.assert_not_called()
 
     def test_sync_gateway_failure_fetches_detail_when_state_ex_data_is_empty(self, mocker):
-        svc = DebugService(template_id=1, space_id=10, pipeline_tree=PIPELINE)
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=PIPELINE_GATEWAY)
         ctx = svc.get_or_create_context()
         svc.sync_node_states()
         ctx.status = "running"
@@ -320,7 +349,45 @@ class TestSyncFromDebugTask:
                 }
             ],
         }
+        gateway = DebugNodeState.objects.get(debug_context=ctx, node_id="G")
+        assert gateway.status == "failed"
+        assert gateway.error_detail == {"type": "runtime", "message": "multiple conditions meet"}
         client.get_task_node_detail.assert_called_once_with(456, "rt_gateway", data={"include_data": True})
+
+    def test_sync_finished_gateway_persists_selected_flows(self, mocker):
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=PIPELINE_GATEWAY)
+        ctx = svc.sync_node_states()
+        ctx.status = "running"
+        ctx.active_task_id = 456
+        ctx.active_run_type = "global"
+        ctx.global_vars = {"${count}": 1}
+        ctx.last_run_status = "running"
+        ctx.save()
+
+        client = mocker.MagicMock()
+        client.get_task_states.return_value = {
+            "result": True,
+            "data": {
+                "state": "FINISHED",
+                "children": {"rt_gateway": {"state": "FINISHED", "elapsed_time": 0.1}},
+            },
+            "message": "",
+        }
+        client.get_node_id_map.return_value = {"result": True, "data": {"G": "rt_gateway"}, "message": ""}
+        client.get_task_node_detail.return_value = {
+            "result": True,
+            "data": {"outputs": [], "version": "v1"},
+            "message": "",
+        }
+        mocker.patch.object(svc, "_task_client", return_value=client)
+
+        svc.sync_from_debug_task(ctx)
+
+        gateway = DebugNodeState.objects.get(debug_context=ctx, node_id="G")
+        assert gateway.status == "finished"
+        assert gateway.outputs["selected_flow_ids"] == ["flow_positive"]
+        assert gateway.outputs["condition_results"][0]["matched"] is True
+        assert gateway.log_ref == {"instance_id": 456, "node_id": "rt_gateway", "version": "v1"}
 
     def test_sync_returns_early_when_node_id_map_fails(self, mocker):
         """id_map 调用失败：不回写、不释放锁，结束结果可在下次重试"""

--- a/tests/interface/template/debug/test_step_run.py
+++ b/tests/interface/template/debug/test_step_run.py
@@ -17,6 +17,8 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 
+import copy
+
 import pytest
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIRequestFactory, force_authenticate
@@ -75,9 +77,116 @@ TREE_DEP = {
     },
 }
 
+TREE_GATEWAY = {
+    "activities": {
+        "A": {"id": "A", "type": "ServiceActivity", "component": {"code": "t", "data": {}}},
+    },
+    "flows": {
+        "flow_positive": {"id": "flow_positive", "source": "G", "target": "A"},
+        "flow_default": {"id": "flow_default", "source": "G", "target": "A"},
+    },
+    "gateways": {
+        "G": {
+            "id": "G",
+            "type": "ExclusiveGateway",
+            "conditions": {"flow_positive": {"name": "positive", "evaluate": "${g1} > 0"}},
+            "default_condition": {"flow_id": "flow_default"},
+            "extra_info": {"parse_lang": "boolrule"},
+        }
+    },
+    "constants": {
+        "${g1}": {
+            "key": "${g1}",
+            "name": "g1",
+            "show_type": "hide",
+            "value": "",
+            "source_type": "component_outputs",
+            "source_info": {"A": ["k1"]},
+            "custom_type": "",
+            "source_tag": "",
+        }
+    },
+}
+
 
 @pytest.mark.django_db
 class TestStepRunAndMock:
+    def test_step_run_gateway_evaluates_path_without_creating_task(self, mocker):
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=TREE_GATEWAY)
+        ctx = svc.get_or_create_context()
+        ctx.global_vars = {"${g1}": 1}
+        ctx.save(update_fields=["global_vars"])
+        svc.sync_node_states()
+        client = mocker.MagicMock()
+        mocker.patch.object(svc, "_task_client", return_value=client)
+
+        result = svc.step_run(node_id="G", operator="admin", mode="real")
+
+        assert result["status"] == "finished"
+        assert result["selected_flow_ids"] == ["flow_positive"]
+        assert result["condition_results"][0]["matched"] is True
+        assert "task_id" not in result
+        client.create_task.assert_not_called()
+        ctx.refresh_from_db()
+        assert ctx.status == "idle"
+        assert ctx.last_run_type == "step"
+        assert ctx.last_run_status == "finished"
+        ns = DebugNodeState.objects.get(debug_context=ctx, node_id="G")
+        assert ns.status == "finished"
+        assert ns.outputs["selected_flow_ids"] == ["flow_positive"]
+
+    def test_step_run_gateway_rejects_mock_mode(self):
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=TREE_GATEWAY)
+        svc.sync_node_states()
+
+        with pytest.raises(DebugStateError, match="条件网关不支持 Mock"):
+            svc.step_run(node_id="G", operator="admin", mode="mock")
+
+    def test_node_mock_rejects_gateway(self):
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=TREE_GATEWAY)
+        svc.sync_node_states()
+
+        with pytest.raises(DebugStateError, match="条件网关不支持 Mock"):
+            svc.node_mock(node_id="G", enable=True)
+
+    def test_step_run_gateway_is_blocked_when_output_dependency_is_missing(self, mocker):
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=TREE_GATEWAY)
+        ctx = svc.get_or_create_context()
+        svc.sync_node_states()
+        client = mocker.MagicMock()
+        mocker.patch.object(svc, "_task_client", return_value=client)
+
+        with pytest.raises(DebugStateError) as exc_info:
+            svc.step_run(node_id="G", operator="admin", mode="real")
+
+        assert exc_info.value.args[0] == {
+            "detail": "依赖未满足",
+            "missing_vars": [{"key": "${g1}", "source_node_id": "A"}],
+        }
+        client.create_task.assert_not_called()
+        ctx.refresh_from_db()
+        assert ctx.status == "idle"
+
+    def test_step_run_gateway_failure_is_persisted_and_releases_lock(self):
+        tree = copy.deepcopy(TREE_GATEWAY)
+        tree["gateways"]["G"]["conditions"] = {
+            "flow_positive": {"name": "first", "evaluate": "1 == 1"},
+            "flow_default": {"name": "second", "evaluate": "2 == 2"},
+        }
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=tree)
+        ctx = svc.sync_node_states()
+
+        result = svc.step_run(node_id="G", operator="admin", mode="real")
+
+        assert result["status"] == "failed"
+        assert result["error_detail"]["type"] == "gateway"
+        assert "多个分支条件同时满足" in result["error_detail"]["message"]
+        ctx.refresh_from_db()
+        assert ctx.status == "idle"
+        assert ctx.last_run_status == "failed"
+        ns = DebugNodeState.objects.get(debug_context=ctx, node_id="G")
+        assert ns.status == "failed"
+
     def test_step_run_mock_success_writes_global_vars(self):
         svc = DebugService(template_id=1, space_id=10, pipeline_tree=TREE)
         ctx = svc.get_or_create_context()
@@ -268,11 +377,11 @@ class TestStepRunViews:
             username="admin", defaults={"is_superuser": True, "is_staff": True}
         )
 
-    def _patch_tree(self, mocker):
+    def _patch_tree(self, mocker, tree=TREE):
         mocker.patch(
             "bkflow.template.debug.service.DebugService.pipeline_tree",
             new_callable=mocker.PropertyMock,
-            return_value=TREE,
+            return_value=tree,
         )
         mocker.patch(
             "bkflow.template.debug.service.DebugService.space_id",
@@ -293,3 +402,22 @@ class TestStepRunViews:
         assert response.status_code == 200
         assert response.data["result"] is False
         assert response.data["data"]["detail"] == {"detail": "节点不存在", "node_id": "ZZZ"}
+
+    def test_step_run_gateway_returns_selected_flows_in_standard_response(self, mocker):
+        self._patch_tree(mocker, tree=TREE_GATEWAY)
+        DebugContext.objects.create(template_id=1, space_id=10, global_vars={"${g1}": 1})
+        view = DebugViewSet.as_view({"post": "step_run"})
+        request = self.factory.post(
+            "/debug/step_run/",
+            {"space_id": 10, "template_id": 1, "node_id": "G", "mode": "real"},
+            format="json",
+        )
+        force_authenticate(request, user=self.user)
+
+        response = view(request)
+
+        assert response.status_code == 200
+        assert response.data["result"] is True
+        assert response.data["data"]["status"] == "finished"
+        assert response.data["data"]["selected_flow_ids"] == ["flow_positive"]
+        assert response.data["data"]["condition_results"][0]["matched"] is True


### PR DESCRIPTION
## 变更内容

- 调试上下文仅返回活动节点、分支网关和条件并行网关，去掉开始、结束、并行网关和汇聚网关。
- 分支网关、条件并行网关支持同步单步调试，并持久化命中路径及条件计算结果。
- 全局调试同步网关节点的成功、失败状态及命中路径。
- 补充条件网关常量解析、依赖检查、接口文档和自动化测试。

## 行为约定

- 条件网关单步调试只计算分支，不创建引擎任务，也不执行下游节点。
- 条件网关固定使用真实模式，不支持 Mock。
- 接口通过 `selected_flow_ids` 返回命中连线，前端据此将对应路径展示为绿色；`condition_results` 返回各分支求值详情。

## 验证

- `pytest tests/interface/template/debug -q`：102 passed
- `pre-commit run --from-ref upstream/develop --to-ref HEAD`：全部通过
- `git diff --check upstream/develop...HEAD`：通过
