### PR TITLE
fix(debug): 按 id 查列表时保留 DEBUG 任务 --story=135505027

### DIFF
--- a/bkflow/task/views.py
+++ b/bkflow/task/views.py
@@ -175,11 +175,32 @@ class TaskInstanceViewSet(
             return RetrieveTaskInstanceSerializer
         return super().get_serializer_class()
 
-    def get_queryset(self):
-        queryset = super().get_queryset()
-        # 调试任务默认不在列表中展示；按 create_method 或按 id 精确查询时保留，供 Token 校验复用
-        query_params = self.request.query_params
-        if self.action == "list" and "create_method" not in query_params and "id" not in query_params:
+    def _should_keep_debug_tasks(self):
+        """列表默认隐藏 DEBUG；显式按 create_method 或按主键查询时保留。
+
+        apply_token / get_task_list?id= 都走 list + id 精确过滤，必须先应用 FilterSet
+        再决定是否隐藏，避免只在 get_queryset 里看 query_params 漏掉 DEBUG。
+        """
+        if self.action != "list":
+            return True
+
+        params = self.request.query_params
+        if "create_method" in params:
+            return True
+
+        for key in ("id", "id__in", "pk"):
+            if hasattr(params, "getlist"):
+                values = params.getlist(key)
+            else:
+                value = params.get(key)
+                values = [value] if value is not None else []
+            if any(str(value) for value in values if value is not None):
+                return True
+        return False
+
+    def filter_queryset(self, queryset):
+        queryset = super().filter_queryset(queryset)
+        if self.action == "list" and not self._should_keep_debug_tasks():
             queryset = queryset.exclude(create_method="DEBUG")
         return queryset
 

--- a/tests/engine/task/test_debug_create_instance.py
+++ b/tests/engine/task/test_debug_create_instance.py
@@ -20,7 +20,11 @@ to the current version of the project delivered to anyone in the future.
 from unittest.mock import MagicMock
 
 import pytest
+from django.conf import settings
+from django.http import QueryDict
 from pipeline.core.constants import PE
+from rest_framework import status
+from rest_framework.test import APIRequestFactory
 
 from bkflow.task.models import TaskInstance, TaskMockData
 from bkflow.task.views import TaskInstanceViewSet
@@ -64,54 +68,105 @@ class TestDebugCreateInstance:
         assert TaskContext(instance).is_mock is True
 
 
-@pytest.mark.django_db
-class TestTaskInstanceViewSetGetQueryset:
-    """直接驱动 TaskInstanceViewSet.get_queryset，避免列表接口的鉴权/空间初始化开销"""
+class TestShouldKeepDebugTasks:
+    """不打数据库，用真实 QueryDict 覆盖 apply_token 的查询串。"""
 
-    def _create_tasks(self):
+    def _viewset(self, action, query_string=""):
+        viewset = TaskInstanceViewSet()
+        viewset.action = action
+        viewset.request = MagicMock()
+        viewset.request.query_params = QueryDict(query_string)
+        return viewset
+
+    def test_keep_debug_when_token_lists_by_id(self):
+        """apply_token 的查询串带 id 时保留 DEBUG。"""
+        viewset = self._viewset("list", "id=180&space_id=205&limit=1&offset=0")
+        assert viewset._should_keep_debug_tasks() is True
+
+    def test_keep_debug_when_filtered_by_create_method(self):
+        """显式按 create_method 过滤时保留 DEBUG。"""
+        viewset = self._viewset("list", "create_method=DEBUG&space_id=205")
+        assert viewset._should_keep_debug_tasks() is True
+
+    def test_hide_debug_on_browse_list(self):
+        """普通列表浏览不带 id 时隐藏 DEBUG。"""
+        viewset = self._viewset("list", "space_id=205&limit=1&offset=0")
+        assert viewset._should_keep_debug_tasks() is False
+
+    def test_keep_debug_on_retrieve(self):
+        """详情接口不过滤 DEBUG。"""
+        viewset = self._viewset("retrieve", "")
+        assert viewset._should_keep_debug_tasks() is True
+
+
+@pytest.mark.django_db
+class TestTaskInstanceListDebugVisibility:
+    """列表接口默认隐藏 DEBUG；按 id 精确查询时必须返回，供 apply_token 复用。"""
+
+    def setup_method(self):
+        self.factory = APIRequestFactory()
+
+    def _create_tasks(self, space_id=205):
         debug_task = TaskInstance.objects.create_instance(
-            pipeline_tree=build_default_pipeline_tree(), space_id=1, create_method="DEBUG", creator="admin"
+            pipeline_tree=build_default_pipeline_tree(), space_id=space_id, create_method="DEBUG", creator="admin"
         )
         api_task = TaskInstance.objects.create_instance(
-            pipeline_tree=build_default_pipeline_tree(), space_id=1, create_method="API", creator="admin"
+            pipeline_tree=build_default_pipeline_tree(), space_id=space_id, create_method="API", creator="admin"
         )
         return debug_task, api_task
 
-    def test_list_hides_debug_by_default(self):
-        debug_task, api_task = self._create_tasks()
-        viewset = TaskInstanceViewSet()
-        viewset.action = "list"
-        viewset.request = MagicMock(query_params={})
+    def _list_request(self, query):
+        request = self.factory.get("/task/", query)
+        request.user = MagicMock()
+        request.user.username = "test_user"
+        request.user.is_superuser = False
+        request.app_internal_token = settings.APP_INTERNAL_TOKEN
+        request.META[f"HTTP_{settings.APP_INTERNAL_SPACE_ID_HEADER_KEY}"] = str(query.get("space_id", "205"))
+        request.META[f"HTTP_{settings.APP_INTERNAL_FROM_SUPERUSER_HEADER_KEY}"] = "0"
+        return request
 
-        task_ids = set(viewset.get_queryset().values_list("id", flat=True))
-        assert api_task.id in task_ids
-        assert debug_task.id not in task_ids
+    def _list(self, query):
+        view = TaskInstanceViewSet.as_view({"get": "list"})
+        return view(self._list_request(query))
+
+    def test_list_hides_debug_by_default(self):
+        """未指定 id / create_method 时，列表不返回 DEBUG 任务。"""
+        debug_task, api_task = self._create_tasks()
+        response = self._list({"space_id": 205, "limit": 10, "offset": 0})
+
+        assert response.status_code == status.HTTP_200_OK
+        result_ids = [item["id"] for item in response.data["data"]["results"]]
+        assert api_task.id in result_ids
+        assert debug_task.id not in result_ids
 
     def test_list_shows_debug_when_filtered_by_create_method(self):
+        """create_method=DEBUG 时列表返回调试任务。"""
         debug_task, _ = self._create_tasks()
-        viewset = TaskInstanceViewSet()
-        viewset.action = "list"
-        viewset.request = MagicMock(query_params={"create_method": "DEBUG"})
+        response = self._list({"space_id": 205, "create_method": "DEBUG", "limit": 10, "offset": 0})
 
-        task_ids = set(viewset.get_queryset().values_list("id", flat=True))
-        assert debug_task.id in task_ids
+        assert response.status_code == status.HTTP_200_OK
+        result_ids = [item["id"] for item in response.data["data"]["results"]]
+        assert debug_task.id in result_ids
 
     def test_list_shows_debug_when_filtered_by_id(self):
-        """按任务 id 精确查询时不过滤 DEBUG，供 Token 校验复用列表接口。"""
+        """apply_token 按 id + space_id 查列表，DEBUG 任务必须 count=1。"""
         debug_task, api_task = self._create_tasks()
-        viewset = TaskInstanceViewSet()
-        viewset.action = "list"
-        viewset.request = MagicMock(query_params={"id": str(debug_task.id)})
+        response = self._list({"id": debug_task.id, "space_id": 205, "limit": 1, "offset": 0})
 
-        task_ids = set(viewset.get_queryset().values_list("id", flat=True))
-        assert debug_task.id in task_ids
-        assert api_task.id in task_ids
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["result"] is True
+        assert response.data["data"]["count"] == 1
+        assert response.data["data"]["results"][0]["id"] == debug_task.id
+        assert response.data["data"]["results"][0]["create_method"] == "DEBUG"
+        assert response.data["data"]["results"][0]["id"] != api_task.id
 
-    def test_non_list_action_keeps_debug(self):
+    def test_retrieve_keeps_debug(self):
+        """详情接口能返回 DEBUG 任务。"""
         debug_task, _ = self._create_tasks()
-        viewset = TaskInstanceViewSet()
-        viewset.action = "retrieve"
-        viewset.request = MagicMock(query_params={})
+        view = TaskInstanceViewSet.as_view({"get": "retrieve"})
+        request = self._list_request({"space_id": 205})
+        response = view(request, pk=debug_task.id)
 
-        task_ids = set(viewset.get_queryset().values_list("id", flat=True))
-        assert debug_task.id in task_ids
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["data"]["id"] == debug_task.id
+        assert response.data["data"]["create_method"] == "DEBUG"


### PR DESCRIPTION
## Summary
- 引擎任务列表改为先按 FilterSet 过滤，再决定是否隐藏 DEBUG。
- `apply_token` / `get_task_list?id=` 按主键查询时能命中 DEBUG 任务，不再报「对应的资源不存在」。
- 普通列表浏览仍默认不展示 DEBUG 任务。

## Test plan
- [ ] `GET /space/205/get_task_list/?id=<DEBUG任务id>&limit=1` 返回 `count=1`
- [ ] 同一任务 `apply_token`（`resource_type=TASK`）申请成功
- [ ] 不带 `id` / `create_method` 的任务列表仍不出现 DEBUG 任务
- [ ] 详情接口仍能打开 DEBUG 任务


Made with [Cursor](https://cursor.com)