### PR TITLE
fix(debug): 允许调试 Token 读取调试数据

### DIFF
--- a/bkflow/template/permissions.py
+++ b/bkflow/template/permissions.py
@@ -16,6 +16,7 @@ We undertake not to change the open source license (MIT license) applicable
 
 to the current version of the project delivered to anyone in the future.
 """
+
 from bkflow.permission.permissions import BaseMockTokenPermission, BaseTokenPermission
 from bkflow.template.serializers.template import TemplateRelatedResourceSerializer
 
@@ -91,9 +92,12 @@ class TemplateRelatedResourcePermission(BaseMockTokenPermission):
         ser = TemplateRelatedResourceSerializer(data=data)
         ser.is_valid(raise_exception=True)
         space_id, template_id = ser.validated_data["space_id"], ser.validated_data["template_id"]
-        action_perm = self.get_action_perm(view)
-        template_permission = getattr(self, f"has_{action_perm}_permission")(
-            request.user.username, space_id, template_id, request.token
+        action_perms = self.get_action_perm(view)
+        if isinstance(action_perms, str):
+            action_perms = (action_perms,)
+        template_permission = any(
+            getattr(self, f"has_{action_perm}_permission")(request.user.username, space_id, template_id, request.token)
+            for action_perm in action_perms
         )
         if not template_permission:
             return self.has_scope_mock_permission(request.user.username, space_id, template_id, request.token)

--- a/bkflow/template/views/debug.py
+++ b/bkflow/template/views/debug.py
@@ -16,6 +16,7 @@ We undertake not to change the open source license (MIT license) applicable
 
 to the current version of the project delivered to anyone in the future.
 """
+
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -46,9 +47,12 @@ def _err(exc, code):
 
 class DebugViewSet(SimpleGenericViewSet):
     permission_classes = [AdminPermission | SpaceSuperuserPermission | TemplateRelatedResourcePermission]
-    # 读操作（context/input_schema/history）按 view 级；写操作（运行/重置/终止）需 mock 及以上权限，
-    # 因为它们会创建/启动/撤销真实的引擎 TaskInstance
-    DEFAULT_PERMISSION = TemplateRelatedResourcePermission.VIEW_PERMISSION
+    # 只读操作既是查看能力，也是调试链路的一部分；写操作需 mock 权限，
+    # 因为它们会创建/启动/撤销真实的引擎 TaskInstance。
+    DEFAULT_PERMISSION = (
+        TemplateRelatedResourcePermission.VIEW_PERMISSION,
+        TemplateRelatedResourcePermission.MOCK_PERMISSION,
+    )
     PERM_MAPPINGS = {
         "global_run": TemplateRelatedResourcePermission.MOCK_PERMISSION,
         "reset": TemplateRelatedResourcePermission.MOCK_PERMISSION,

--- a/tests/interface/template/debug/test_permissions.py
+++ b/tests/interface/template/debug/test_permissions.py
@@ -1,0 +1,77 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
+Copyright (C) 2024 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+
+to the current version of the project delivered to anyone in the future.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from django.utils import timezone
+from rest_framework.test import APIRequestFactory
+
+from bkflow.permission.models import PermissionType, ResourceType, Token
+from bkflow.template.permissions import TemplateRelatedResourcePermission
+from bkflow.template.views.debug import DebugViewSet
+
+
+@pytest.mark.django_db
+class TestDebugTokenPermission:
+    def setup_method(self):
+        self.factory = APIRequestFactory()
+        self.permission = TemplateRelatedResourcePermission()
+
+    def _request(self, token):
+        request = self.factory.get("/debug/context/")
+        request.user = MagicMock(username="testuser")
+        request.token = token
+        request.query_params = {"space_id": "1", "template_id": "407"}
+        request.data = {}
+        return request
+
+    def _create_token(self, token, permission_type, resource_id="407"):
+        Token.objects.create(
+            token=token,
+            space_id=1,
+            user="testuser",
+            resource_type=ResourceType.TEMPLATE.value,
+            resource_id=resource_id,
+            permission_type=permission_type,
+            expired_time=timezone.now() + timezone.timedelta(hours=1),
+        )
+
+    @pytest.mark.parametrize("action", ["context", "input_schema", "history", "reset_impact"])
+    def test_mock_token_can_access_debug_read_action(self, action):
+        self._create_token("mock_token", PermissionType.MOCK.value)
+        view = DebugViewSet()
+        view.action = action
+
+        assert self.permission.has_permission(self._request("mock_token"), view) is True
+
+    @pytest.mark.parametrize("action", ["global_run", "reset", "terminate", "step_run", "node_mock", "context_var"])
+    def test_view_token_cannot_access_debug_write_action(self, action):
+        self._create_token("view_token", PermissionType.VIEW.value)
+        view = DebugViewSet()
+        view.action = action
+
+        assert self.permission.has_permission(self._request("view_token"), view) is False
+
+    def test_mock_token_cannot_access_another_template(self):
+        self._create_token("other_template_token", PermissionType.MOCK.value, resource_id="408")
+        view = DebugViewSet()
+        view.action = "context"
+
+        assert self.permission.has_permission(self._request("other_template_token"), view) is False


### PR DESCRIPTION
## 问题

TEMPLATE + MOCK Token 调用调试只读接口时，权限类只校验 TEMPLATE + VIEW，随后仅回退校验 SCOPE + MOCK，导致同模板调试 Token 被拒绝。

## 变更内容

- 调试只读接口 context、input_schema、history、reset_impact 同时接受 TEMPLATE + VIEW 和 TEMPLATE + MOCK
- global_run、reset、terminate、step_run、node_mock、context_var 等写接口仍只接受 MOCK
- 保留空间、用户、模板资源和过期时间校验，跨模板 Token 仍被拒绝
- 新增调试 Token 权限回归测试

## 验证

- 修复前：4 个 MOCK Token 只读场景稳定返回 False
- 调试模块：120 passed
- 模板接口完整回归：243 passed
- pre-commit：black、isort、flake8、pyupgrade 均通过