### PR TITLE
fix(open-plugin): 默认选择最新版本并保留任务参数

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "build:development": "cross-env DEV_VAR=development webpack --config ./build/webpack.prod.conf.js",
     "build:production": "cross-env DEV_VAR=production webpack --config ./build/webpack.prod.conf.js",
     "test:render-form-schema": "node tests/renderFormSchema.test.js",
-    "test:plugin-form": "node tests/renderFormSchema.test.js && node tests/pluginFormLoader.test.js && node tests/uniformApi.test.mjs && node tests/atomForm.test.js && node tests/legacyApiPluginCompatibility.test.js",
+    "test:plugin-form": "node tests/renderFormSchema.test.js && node tests/pluginFormLoader.test.js && node tests/uniformApi.test.mjs && node tests/atomForm.test.js && node tests/legacyApiPluginCompatibility.test.js && node tests/createTaskSideslider.test.js",
     "lint": "eslint --ext .js,.vue src/",
     "fix": "eslint --fix --ext .js,.vue src/"
   },

--- a/frontend/src/utils/uniformApi.js
+++ b/frontend/src/utils/uniformApi.js
@@ -454,16 +454,16 @@ export const resolveNodeExecutionPayload = (nodeInfo = {}) => {
 };
 
 /**
- * 新选择且尚未保存的节点：优先使用目录 default_version，
- * latest_version 只作为异常数据兼容。
+ * 新选择且尚未保存的节点：优先使用目录 latest_version，
+ * default_version 只作为异常数据兼容。
  */
 export const resolveNewOpenPluginVersion = ({
   defaultVersion,
   latestVersion,
   versions = [],
 } = {}) => {
-  if (hasValue(defaultVersion)) return defaultVersion;
   if (hasValue(latestVersion)) return latestVersion;
+  if (hasValue(defaultVersion)) return defaultVersion;
   const last = versions[versions.length - 1];
   if (!last) return '';
   return typeof last === 'string' ? last : (last.version || '');

--- a/frontend/src/views/admin/Space/Template/CreateTaskSideslider.vue
+++ b/frontend/src/views/admin/Space/Template/CreateTaskSideslider.vue
@@ -257,7 +257,7 @@ export default {
                 const isFormValid = await this.$refs.createTaskForm.validate();
                 const isParamsValid = this.taskFormData.mode === 'json'
                         ? this.isJsonConstantsValid
-                        : this.$refs.taskParamEdit.validate();
+                        : await this.$refs.taskParamEdit.validate();
 
                 if (!isFormValid || !isParamsValid) {
                     this.createLoading = false;
@@ -265,12 +265,13 @@ export default {
                 }
 
                 this.createLoading = true;
+                const constants = await this.getParameterConstants();
                 const resp = await this.createTask({
                     spaceId: this.spaceId,
                     params: {
                         ...this.taskFormData,
                         label_ids: this.taskFormData.labels.map(label => label.id),
-                        constants: this.getParameterConstants(),
+                        constants,
                     },
                 });
 
@@ -297,12 +298,12 @@ export default {
                 this.createLoading = false;
             }
         },
-        getParameterConstants() {
+        async getParameterConstants() {
             const { constants, mode } = this.taskFormData;
             if (mode === 'json') {
                 return JSON.parse(constants);
             }
-            const variableData = this.$refs.taskParamEdit.getVariableData();
+            const variableData = await this.$refs.taskParamEdit.getVariableData();
             return Object.values(variableData).reduce(
                 (acc, cur) => Object.assign(acc, { [cur.key]: cur.value }),
                 {}

--- a/frontend/src/views/template/TemplateEdit/NodeConfig/NodeConfig.vue
+++ b/frontend/src/views/template/TemplateEdit/NodeConfig/NodeConfig.vue
@@ -1352,7 +1352,7 @@
           desc = descList.join('<br>');
         }
         // 对于API插件，优先使用basicInfo中已存储的version（可能来自meta API返回），否则使用默认值
-        // 新节点默认使用 default_version，latest_version 仅作异常数据兼容
+        // 新节点默认使用 latest_version，default_version 仅作异常数据兼容
         let apiPluginVersion = null;
         if (this.isApiPlugin) {
           apiPluginVersion = resolveNewOpenPluginVersion({

--- a/frontend/tests/createTaskSideslider.test.js
+++ b/frontend/tests/createTaskSideslider.test.js
@@ -1,0 +1,110 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const babel = require('@babel/core');
+
+function loadComponent() {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../src/views/admin/Space/Template/CreateTaskSideslider.vue'),
+    'utf8',
+  );
+  const script = source.match(/<script>([\s\S]*?)<\/script>/);
+  assert.ok(script, 'CreateTaskSideslider.vue must contain a script block');
+
+  const transformed = babel.transformSync(script[1], {
+    plugins: ['@babel/plugin-transform-modules-commonjs'],
+  });
+  const module = { exports: {} };
+  const fallbackModule = {
+    __esModule: true,
+    default: {},
+  };
+  const mocks = {
+    vuex: {
+      __esModule: true,
+      mapActions: () => ({}),
+      mapMutations: () => ({}),
+      mapState: () => ({}),
+    },
+    'moment-timezone': {
+      __esModule: true,
+      default: () => ({ format: () => '20260825180000' }),
+    },
+    '@/constants/index.js': { STRING_LENGTH: {} },
+    '@/utils/tools.js': {
+      __esModule: true,
+      default: { checkIsJSON: () => true },
+    },
+  };
+  const localRequire = id => mocks[id] || fallbackModule;
+  // eslint-disable-next-line no-new-func
+  new Function('require', 'module', 'exports', transformed.code)(localRequire, module, module.exports);
+  return module.exports.default || module.exports;
+}
+
+async function testCreateTaskAwaitsValidationAndVariableData() {
+  const component = loadComponent();
+  const calls = [];
+  const context = {
+    taskFormData: {
+      mode: 'form',
+      name: 'task',
+      labels: [],
+    },
+    spaceId: 245,
+    createLoading: false,
+    $refs: {
+      createTaskForm: {
+        validate: async () => true,
+      },
+      taskParamEdit: {
+        validate: async () => true,
+        getVariableData: async () => ({
+          ip: { key: '${ip}', value: '0:9.136.163.56' },
+        }),
+      },
+    },
+    createTask: async (payload) => {
+      calls.push(payload);
+      return { result: false };
+    },
+    getParameterConstants: component.methods.getParameterConstants,
+  };
+
+  await component.methods.createTaskConfirm.call(context);
+
+  assert.equal(calls.length, 1);
+  assert.deepStrictEqual(calls[0].params.constants, {
+    '${ip}': '0:9.136.163.56',
+  });
+}
+
+async function testCreateTaskStopsWhenParameterValidationFails() {
+  const component = loadComponent();
+  let createCalled = false;
+  const context = {
+    taskFormData: { mode: 'form', labels: [] },
+    createLoading: false,
+    $refs: {
+      createTaskForm: { validate: async () => true },
+      taskParamEdit: { validate: async () => false },
+    },
+    createTask: async () => {
+      createCalled = true;
+    },
+  };
+
+  await component.methods.createTaskConfirm.call(context);
+
+  assert.equal(createCalled, false);
+}
+
+Promise.resolve()
+  .then(testCreateTaskAwaitsValidationAndVariableData)
+  .then(testCreateTaskStopsWhenParameterValidationFails)
+  .then(() => console.log('CreateTaskSideslider tests passed'))
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/frontend/tests/uniformApi.test.mjs
+++ b/frontend/tests/uniformApi.test.mjs
@@ -733,12 +733,12 @@ async function main() {
     assert.equal(component.data.mark, 'explicit');
   });
 
-  test('resolveNewOpenPluginVersion prefers default_version over latest_version', () => {
+  test('resolveNewOpenPluginVersion prefers latest_version over default_version', () => {
     assert.equal(resolveNewOpenPluginVersion({
       defaultVersion: '1.0.0',
       latestVersion: '2.0.0',
       versions: ['1.0.0', '2.0.0'],
-    }), '1.0.0');
+    }), '2.0.0');
     assert.equal(resolveNewOpenPluginVersion({
       latestVersion: '2.0.0',
       versions: [{ version: '1.0.0' }, { version: '2.0.0' }],

--- a/tests/plugins/uniform_api/test_api_plugin_vue.py
+++ b/tests/plugins/uniform_api/test_api_plugin_vue.py
@@ -437,7 +437,7 @@ def test_node_config_assigns_saved_inputs_before_loading_v4_form():
     )
 
 
-def test_new_open_plugin_node_prefers_default_version():
+def test_new_open_plugin_node_prefers_latest_version():
     source = read("frontend/src/views/template/TemplateEdit/NodeConfig/NodeConfig.vue")
     helper = read("frontend/src/utils/uniformApi.js")
 
@@ -445,6 +445,7 @@ def test_new_open_plugin_node_prefers_default_version():
     assert "resolveNewOpenPluginVersion" in helper
     assert "defaultVersion: val.default_version" in source
     assert "latestVersion: val.latest_version" in source
+    assert helper.index("if (hasValue(latestVersion))") < helper.index("if (hasValue(defaultVersion))")
 
 
 def test_task_param_edit_recovers_v4_component_from_pipeline_activities():


### PR DESCRIPTION
## 问题
- V4 API 插件新节点优先采用 `default_version`，标准运维内置插件因此会选中 `legacy` 等最早版本
- 空间模板页新建任务时，参数校验与 `getVariableData()` 为异步调用，但提交逻辑未等待结果，可能把表单参数提交为 `{}`

## 修改
- 仅对新选择、尚未保存的 V4 API 插件优先采用 `latest_version`，异常数据再回退 `default_version`；存量节点继续使用已保存版本
- 新建任务时等待参数校验及参数收集完成后再调用创建接口
- 增加版本选择和异步参数提交回归测试

## 验证
- `npm run test:plugin-form`：通过
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts='' tests/plugins/uniform_api/test_api_plugin_vue.py -v`：36 passed
- 修改文件 ESLint：通过
- 生产构建进入完整打包后，被本地基线缺失 `@blueking/bkflow-canvas-editor-vue2/style`、`@blueking/crypto-js-sdk` 依赖阻断，与本次变更无关

关联需求：133649781