### PR TITLE
fix(task): 兼容无 location 的调试最小树创建任务

### DIFF
--- a/bkflow/pipeline_plugins/components/collections/subprocess_plugin/converter.py
+++ b/bkflow/pipeline_plugins/components/collections/subprocess_plugin/converter.py
@@ -71,7 +71,7 @@ class PipelineTreeSubprocessConverter:
                         if key in self.constants:
                             constant["value"] = self.constants[key]
 
-        for location in self.pipeline_tree["location"]:
+        for location in self.pipeline_tree.get("location") or []:
             if location["type"] == "subflow":
                 location["type"] = "tasknode"
 

--- a/tests/plugins/components/collections/subprocess_plugin/test_converter.py
+++ b/tests/plugins/components/collections/subprocess_plugin/test_converter.py
@@ -213,3 +213,51 @@ class PipelineTreeSubprocessConverterTest(TestCase):
         converter.convert()
 
         self.assertEqual(converter.pipeline_tree["constants"], original_constants)
+
+    def test_convert_method_without_location_key(self):
+        """调试最小树没有 location 时，convert 不应抛 KeyError"""
+        pipeline_tree = {
+            "activities": {
+                "node1": {
+                    "id": "node1",
+                    "name": "普通节点",
+                    "type": "ServiceActivity",
+                },
+                "node2": {
+                    "id": "node2",
+                    "name": "子流程节点",
+                    "type": "SubProcess",
+                    "template_id": "template_123",
+                },
+            },
+            "constants": [],
+        }
+
+        converter = PipelineTreeSubprocessConverter(pipeline_tree)
+        converter.convert()
+
+        activities = converter.pipeline_tree["activities"]
+        self.assertEqual(activities["node1"]["type"], "ServiceActivity")
+        self.assertEqual(activities["node2"]["type"], "ServiceActivity")
+        self.assertEqual(activities["node2"]["component"]["code"], "subprocess_plugin")
+        self.assertNotIn("location", converter.pipeline_tree)
+
+    def test_convert_method_with_location_none(self):
+        """location 为 None 时，convert 应视为空列表，不抛异常"""
+        pipeline_tree = {
+            "activities": {
+                "node1": {
+                    "id": "node1",
+                    "name": "普通节点",
+                    "type": "ServiceActivity",
+                },
+            },
+            "constants": [],
+            "location": None,
+        }
+
+        converter = PipelineTreeSubprocessConverter(pipeline_tree)
+        converter.convert()
+
+        self.assertEqual(converter.pipeline_tree["activities"]["node1"]["type"], "ServiceActivity")
+        self.assertIsNone(converter.pipeline_tree["location"])


### PR DESCRIPTION
## Summary
- 真实单步调试 / 「重新调试」会构造不含 `location` 的最小 `pipeline_tree`（`start → node → end`），再 `POST /task/` 创建任务。
- `TaskInstance.create_instance()` 总会调用 `PipelineTreeSubprocessConverter.convert()`，原先硬读 `pipeline_tree["location"]`，缺字段时抛 `KeyError`，被包装成 `50000` / 「系统异常,请联系管理员处理」。
- 本次将 `location` 缺失或为 `None` 视为空列表，跳过画布坐标改写；完整画布树里 `subflow → tasknode` 的改写逻辑保持不变。

相关 TAPD：https://tapd.woa.com/70120217/bugtrace/bugs/view/1070120217162836631

## Test plan
- [x] `pytest tests/plugins/components/collections/subprocess_plugin/test_converter.py --no-cov`（含无 `location`、`location=None`）
- [ ] 发布 **bkfara-engine**（仅发 default-engine 无法覆盖分析处置生产）
- [ ] 在使用 bkfara-engine 的空间上做真实单步调试 / 「重新调试」，`POST /task/` 不再 500
- [ ] 全局调试 / 完整画布树创建任务仍正常
- [ ] 含子流程节点的完整树创建后，`location` 中 `subflow` 仍会改写为 `tasknode`


Made with [Cursor](https://cursor.com)