### PR TITLE
fix(frontend): 修复图片模块导致的页面白屏 --bug=163214553

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,8 +9,9 @@
     "build": "cross-env npm run build:production",
     "build:development": "cross-env DEV_VAR=development webpack --config ./build/webpack.prod.conf.js",
     "build:production": "cross-env DEV_VAR=production webpack --config ./build/webpack.prod.conf.js",
+    "test:static-image-imports": "node tests/staticImageImports.test.js",
     "test:render-form-schema": "node tests/renderFormSchema.test.js",
-    "test:plugin-form": "node tests/renderFormSchema.test.js && node tests/pluginFormLoader.test.js && node tests/uniformApi.test.mjs && node tests/atomForm.test.js && node tests/legacyApiPluginCompatibility.test.js && node tests/legacyApiVariableForm.test.js && node tests/createTaskSideslider.test.js",
+    "test:plugin-form": "node tests/renderFormSchema.test.js && node tests/pluginFormLoader.test.js && node tests/uniformApi.test.mjs && node tests/atomForm.test.js && node tests/legacyApiPluginCompatibility.test.js && node tests/legacyApiVariableForm.test.js && node tests/createTaskSideslider.test.js && node tests/staticImageImports.test.js",
     "lint": "eslint --ext .js,.vue src/",
     "fix": "eslint --fix --ext .js,.vue src/"
   },

--- a/frontend/src/components/canvas/ProcessCanvas/components/dnd/index.vue
+++ b/frontend/src/components/canvas/ProcessCanvas/components/dnd/index.vue
@@ -16,6 +16,12 @@
   </div>
 </template>
 <script>
+  import leftTasknodeGuideUrl from '@/assets/images/left-tasknode-guide.gif';
+  import leftSubflowGuideUrl from '@/assets/images/left-subflow-guide.gif';
+  import leftParallelgatewayGuideUrl from '@/assets/images/left-parallelgateway-guide.gif';
+  import leftBranchgatewayGuideUrl from '@/assets/images/left-branchgateway-guide.gif';
+  import leftConvergegatewayGuideUrl from '@/assets/images/left-convergegateway-guide.gif';
+  import leftBranchConvergeGatewayGuideUrl from '@/assets/images/left-branch-converge-gateway-guide.gif';
   import { Graph } from '@antv/x6';
   import { Dnd } from '@/utils/dnd.js';
   import { uuid } from '@/utils/uuid.js';
@@ -162,7 +168,7 @@
         const nodesGuide = [
           {
             el: '.node-item[data-type=task]',
-            url: require('@/assets/images/left-tasknode-guide.gif'),
+            url: leftTasknodeGuideUrl,
             text: [
               {
                 type: 'name',
@@ -176,7 +182,7 @@
           },
           {
             el: '.node-item[data-type=subflow]',
-            url: require('@/assets/images/left-subflow-guide.gif'),
+            url: leftSubflowGuideUrl,
             text: [
               {
                 type: 'name',
@@ -190,7 +196,7 @@
           },
           {
             el: '.node-item[data-type=parallel-gateway]',
-            url: require('@/assets/images/left-parallelgateway-guide.gif'),
+            url: leftParallelgatewayGuideUrl,
             text: [
               {
                 type: 'name',
@@ -204,7 +210,7 @@
           },
           {
             el: '.node-item[data-type=branch-gateway]',
-            url: require('@/assets/images/left-branchgateway-guide.gif'),
+            url: leftBranchgatewayGuideUrl,
             text: [
               {
                 type: 'name',
@@ -218,7 +224,7 @@
           },
           {
             el: '.node-item[data-type=converge-gateway]',
-            url: require('@/assets/images/left-convergegateway-guide.gif'),
+            url: leftConvergegatewayGuideUrl,
             text: [
               {
                 type: 'name',
@@ -232,7 +238,7 @@
           },
           {
             el: '.node-item[data-type=conditional-parallel-gateway]',
-            url: require('@/assets/images/left-branch-converge-gateway-guide.gif'),
+            url: leftBranchConvergeGatewayGuideUrl,
             text: [
               {
                 type: 'name',

--- a/frontend/src/components/common/Individualization/cronRuleSelect.vue
+++ b/frontend/src/components/common/Individualization/cronRuleSelect.vue
@@ -95,6 +95,8 @@
   import CronExpression from 'cron-parser-custom';
   import Translate from '@/utils/cron.js';
   import tools from '@/utils/tools.js';
+  import taskZhUrl from '@/assets/images/task-zh.png';
+  import taskEnUrl from '@/assets/images/task-en.png';
   const labelIndexMap = {
     minute: 0,
     hour: 1,
@@ -124,7 +126,7 @@
         errorField: '',
         isError: false,
         isTimeMore: false,
-        periodicCronImg: require(`@/assets/images/${i18n.t('task-zh')}.png`),
+        periodicCronImg: { 'task-zh': taskZhUrl, 'task-en': taskEnUrl }[i18n.t('task-zh')],
         ruleTipsHtmlConfig: {
           allowHtml: true,
           width: 560,

--- a/frontend/src/components/common/Individualization/loopRuleSelect.vue
+++ b/frontend/src/components/common/Individualization/loopRuleSelect.vue
@@ -143,6 +143,8 @@
   import i18n from '@/config/i18n/index.js';
   import { PERIODIC_REG } from '@/constants/index.js';
   import tools from '@/utils/tools.js';
+  import taskZhUrl from '@/assets/images/task-zh.png';
+  import taskEnUrl from '@/assets/images/task-en.png';
   const autoRuleList = [
     {
       key: 'min',
@@ -264,7 +266,7 @@
           regex: PERIODIC_REG,
         },
         expressionList: ['*', '*', '*', '*', '*'],
-        periodicCronImg: require(`@/assets/images/${i18n.t('task-zh')}.png`),
+        periodicCronImg: { 'task-zh': taskZhUrl, 'task-en': taskEnUrl }[i18n.t('task-zh')],
         // 规则列表
         autoRuleList: [],
         // 循环选择方式

--- a/frontend/src/components/common/TemplateCanvas/PalettePanel/index.vue
+++ b/frontend/src/components/common/TemplateCanvas/PalettePanel/index.vue
@@ -83,6 +83,12 @@
   </div>
 </template>
 <script>
+  import leftTasknodeGuideUrl from '@/assets/images/left-tasknode-guide.gif';
+  import leftSubflowGuideUrl from '@/assets/images/left-subflow-guide.gif';
+  import leftParallelgatewayGuideUrl from '@/assets/images/left-parallelgateway-guide.gif';
+  import leftBranchgatewayGuideUrl from '@/assets/images/left-branchgateway-guide.gif';
+  import leftConvergegatewayGuideUrl from '@/assets/images/left-convergegateway-guide.gif';
+  import leftBranchConvergeGatewayGuideUrl from '@/assets/images/left-branch-converge-gateway-guide.gif';
   import i18n from '@/config/i18n/index.js';
   import NodeMenu from './NodeMenu/NodeMenu.vue';
   import Guide from '@/utils/guide.js';
@@ -178,7 +184,7 @@
         const nodesGuide = [
           {
             el: '.entry-item[data-type=tasknode]',
-            url: require('@/assets/images/left-tasknode-guide.gif'),
+            url: leftTasknodeGuideUrl,
             text: [
               {
                 type: 'name',
@@ -192,7 +198,7 @@
           },
           {
             el: '.entry-item[data-type=subflow]',
-            url: require('@/assets/images/left-subflow-guide.gif'),
+            url: leftSubflowGuideUrl,
             text: [
               {
                 type: 'name',
@@ -206,7 +212,7 @@
           },
           {
             el: '.entry-item[data-type=parallelgateway]',
-            url: require('@/assets/images/left-parallelgateway-guide.gif'),
+            url: leftParallelgatewayGuideUrl,
             text: [
               {
                 type: 'name',
@@ -220,7 +226,7 @@
           },
           {
             el: '.entry-item[data-type=branchgateway]',
-            url: require('@/assets/images/left-branchgateway-guide.gif'),
+            url: leftBranchgatewayGuideUrl,
             text: [
               {
                 type: 'name',
@@ -234,7 +240,7 @@
           },
           {
             el: '.entry-item[data-type=convergegateway]',
-            url: require('@/assets/images/left-convergegateway-guide.gif'),
+            url: leftConvergegatewayGuideUrl,
             text: [
               {
                 type: 'name',
@@ -248,7 +254,7 @@
           },
           {
             el: '.entry-item[data-type=conditionalparallelgateway]',
-            url: require('@/assets/images/left-branch-converge-gateway-guide.gif'),
+            url: leftBranchConvergeGatewayGuideUrl,
             text: [
               {
                 type: 'name',

--- a/frontend/src/components/common/base/NoData.vue
+++ b/frontend/src/components/common/base/NoData.vue
@@ -34,6 +34,8 @@
   </div>
 </template>
 <script>
+  import notDataUrl from '@/assets/images/not-data.png';
+  import searchEmptyUrl from '@/assets/images/search-empty.png';
   export default {
     name: 'NoData',
     props: {
@@ -48,8 +50,8 @@
     },
     data() {
       return {
-        notDataUrl: require('@/assets/images/not-data.png'),
-        searchEmptyUrl: require('@/assets/images/search-empty.png'),
+        notDataUrl,
+        searchEmptyUrl,
       };
     },
   };

--- a/frontend/src/components/common/modal/ErrorCodeModal.vue
+++ b/frontend/src/components/common/modal/ErrorCodeModal.vue
@@ -40,6 +40,7 @@
   </bk-dialog>
 </template>
 <script>
+  import expre500Url from '@/assets/images/expre_500.png';
   import ErrorCode403 from './ErrorCode403.vue';
   import ErrorCode500 from './ErrorCode500.vue';
   export default {
@@ -54,7 +55,7 @@
         code: '',
         responseText: '',
         title: ' ',
-        expPic500: require('@/assets/images/expre_500.png'),
+        expPic500: expre500Url,
       };
     },
     methods: {

--- a/frontend/src/components/common/modal/home.vue
+++ b/frontend/src/components/common/modal/home.vue
@@ -170,26 +170,42 @@
 </template>
 
 <script>
+  import titleBgBlueUrl from '@/assets/images/home/title-bg-blue.png';
+  import titleBgOrangeUrl from '@/assets/images/home/title-bg-orange.png';
+  import bkFlowUrl from '@/assets/images/home/bk-flow.png';
+  import illustration1Url from '@/assets/images/home/illustration-1.png';
+  import functionBgUrl from '@/assets/images/home/function-bg.png';
+  import function1Url from '@/assets/images/home/function-1.png';
+  import function2Url from '@/assets/images/home/function-2.png';
+  import function3Url from '@/assets/images/home/function-3.png';
+  import accessBgUrl from '@/assets/images/home/access-bg.png';
+  import illustration2Url from '@/assets/images/home/illustration-2.png';
+  import accessTitleUrl from '@/assets/images/home/access-title.png';
+  import plugin1Url from '@/assets/images/home/plugin-1.png';
+  import plugin2Url from '@/assets/images/home/plugin-2.png';
+  import plugin3Url from '@/assets/images/home/plugin-3.png';
+  import plugin4Url from '@/assets/images/home/plugin-4.png';
+  import accessTitleEnUrl from '@/assets/images/home/access-title-en.png';
   export default {
     name: 'Home',
     data() {
       return {
-        image1: require('@/assets/images/home/title-bg-blue.png'),
-        image2: require('@/assets/images/home/title-bg-orange.png'),
-        image3: require('@/assets/images/home/bk-flow.png'),
-        image4: require('@/assets/images/home/illustration-1.png'),
-        image5: require('@/assets/images/home/function-bg.png'),
-        image6: require('@/assets/images/home/function-1.png'),
-        image7: require('@/assets/images/home/function-2.png'),
-        image8: require('@/assets/images/home/function-3.png'),
-        image9: require('@/assets/images/home/access-bg.png'),
-        image10: require('@/assets/images/home/illustration-2.png'),
-        image11: require('@/assets/images/home/access-title.png'),
-        image12: require('@/assets/images/home/plugin-1.png'),
-        image13: require('@/assets/images/home/plugin-2.png'),
-        image14: require('@/assets/images/home/plugin-3.png'),
-        image15: require('@/assets/images/home/plugin-4.png'),
-        image16: require('@/assets/images/home/access-title-en.png'),
+        image1: titleBgBlueUrl,
+        image2: titleBgOrangeUrl,
+        image3: bkFlowUrl,
+        image4: illustration1Url,
+        image5: functionBgUrl,
+        image6: function1Url,
+        image7: function2Url,
+        image8: function3Url,
+        image9: accessBgUrl,
+        image10: illustration2Url,
+        image11: accessTitleUrl,
+        image12: plugin1Url,
+        image13: plugin2Url,
+        image14: plugin3Url,
+        image15: plugin4Url,
+        image16: accessTitleEnUrl,
         isEnglish: false,
       };
     },

--- a/frontend/src/components/layout/Navigation.vue
+++ b/frontend/src/components/layout/Navigation.vue
@@ -26,6 +26,7 @@
 </template>
 
 <script>
+  import logoUrl from '../../assets/images/logo.png';
   import { mapState, mapActions, mapMutations } from 'vuex';
   import NavigatorHeadLeft from './NavigationHeadLeft.vue';
   import NavigatorHeadRight from './NavigationHeadRight.vue';
@@ -39,7 +40,7 @@
     },
     data() {
       return {
-        logo: require('../../assets/images/logo.png'),
+        logo: logoUrl,
         isExpand: false,
       };
     },

--- a/frontend/src/views/admin/Space/Credential/components/CredentialSlider.vue
+++ b/frontend/src/views/admin/Space/Credential/components/CredentialSlider.vue
@@ -212,6 +212,8 @@
 </template>
 
 <script>
+  import apigwUrl from '@/assets/images/apigw.png';
+  import apigwAccessTokenUrl from '@/assets/images/apigw_access_token.png';
 import { cloneDeepWith } from 'lodash';
 import { mapActions } from 'vuex';
 import { CREDENTIAL_TYPE_LIST, CREDENTIAL_OPEN_SCOPE_LIST } from '@/constants';
@@ -400,11 +402,11 @@ export default {
     },
     getImageUrl() {
       if (this.isApp) {
-        return require('@/assets/images/apigw.png');
+        return apigwUrl;
       }
 
       if (this.isAccessToken) {
-        return require('@/assets/images/apigw_access_token.png');
+        return apigwAccessTokenUrl;
       }
 
       return '';

--- a/frontend/src/views/template/TemplateEdit/TemplateSetting/CronRuleSelect.vue
+++ b/frontend/src/views/template/TemplateEdit/TemplateSetting/CronRuleSelect.vue
@@ -100,6 +100,8 @@
     import CronExpression from 'cron-parser-custom';
     import Translate from '@/utils/cron.js';
     import tools from '@/utils/tools.js';
+    import taskZhUrl from '@/assets/images/task-zh.png';
+    import taskEnUrl from '@/assets/images/task-en.png';
     const labelIndexMap = {
         minute: 0,
         hour: 1,
@@ -133,7 +135,7 @@
                 errorField: '',
                 isError: false,
                 isTimeMore: false,
-                periodicCronImg: require(`@/assets/images/${i18n.t('task-zh')}.png`),
+                periodicCronImg: { 'task-zh': taskZhUrl, 'task-en': taskEnUrl }[i18n.t('task-zh')],
                 ruleTipsHtmlConfig: {
                     extCls: 'periodic-cron-tips',
                     allowHtml: true,

--- a/frontend/src/views/template/TemplateEdit/index.vue
+++ b/frontend/src/views/template/TemplateEdit/index.vue
@@ -209,6 +209,7 @@
   </div>
 </template>
 <script>
+  import nodeDoubleClickGuideUrl from '@/assets/images/node-double-click-guide.gif';
   import i18n from '@/config/i18n/index.js';
   import { mapState, mapGetters, mapActions, mapMutations } from 'vuex';
   // moment用于时区使用
@@ -326,7 +327,7 @@
           arrow: true,
           img: {
             height: 112,
-            url: require('@/assets/images/node-double-click-guide.gif'),
+            url: nodeDoubleClickGuideUrl,
           },
           text: [
             {

--- a/frontend/tests/staticImageImports.test.js
+++ b/frontend/tests/staticImageImports.test.js
@@ -1,0 +1,79 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const createLoader = require('./helpers/loadSourceModule');
+
+const sourceRoot = path.resolve(__dirname, '../src');
+const cases = [
+  ['components/layout/Navigation.vue', ['logo']],
+  ['components/common/base/NoData.vue', ['notDataUrl', 'searchEmptyUrl']],
+  ['components/common/modal/ErrorCodeModal.vue', ['expPic500']],
+  ['components/common/modal/home.vue', Array.from({ length: 16 }, (_, index) => `image${index + 1}`)],
+];
+
+function assetModule(name) {
+  // Match the Module namespace object captured in the STAG img.src failure.
+  return Object.assign(Object.create(null), {
+    __esModule: true,
+    default: `/static/${name}`,
+    [Symbol.toStringTag]: 'Module',
+  });
+}
+
+for (const [file, fields] of cases) {
+  test(`${file}: image bindings remain URL strings when the bundler returns an ES module`, () => {
+    const source = fs.readFileSync(path.join(sourceRoot, file), 'utf8');
+    const component = { __esModule: true, default: {} };
+    const mocks = {
+      vuex: { mapState: () => ({}), mapActions: () => ({}), mapMutations: () => ({}) },
+      './NavigationHeadLeft.vue': component,
+      './NavigationHeadRight.vue': component,
+      './NavigationMenu.vue': component,
+      './ErrorCode403.vue': component,
+      './ErrorCode500.vue': component,
+    };
+    for (const [, asset] of source.matchAll(/['"]([^'"]+\.(?:png|jpe?g|gif|svg))['"]/g)) {
+      mocks[asset] = assetModule(path.basename(asset));
+    }
+    const values = createLoader(mocks)(file).default.data();
+    for (const field of fields) {
+      assert.equal(typeof values[field], 'string', `${field} must be a URL, not a module namespace`);
+      assert.match(String(values[field]), /^\/static\/.+\.(png|jpe?g|gif|svg)$/);
+    }
+  });
+}
+
+for (const file of [
+  'components/common/Individualization/cronRuleSelect.vue',
+  'components/common/Individualization/loopRuleSelect.vue',
+  'views/template/TemplateEdit/TemplateSetting/CronRuleSelect.vue',
+]) {
+  for (const language of ['zh', 'en']) {
+    test(`${file}: cron illustration remains a URL for ${language}`, (context) => {
+      const previousWindow = global.window;
+      global.window = { PERIODIC_TASK_SHORTEST_TIME: 5 };
+      context.after(() => {
+        if (previousWindow === undefined) delete global.window;
+        else global.window = previousWindow;
+      });
+      const mocks = {
+        '@/config/i18n/index.js': {
+          __esModule: true,
+          default: {
+            t: value => value === 'task-zh' ? `task-${language}` : value,
+            tc: value => value,
+          },
+        },
+        '@/assets/images/task-zh.png': assetModule('task-zh.png'),
+        '@/assets/images/task-en.png': assetModule('task-en.png'),
+        '@/constants/index.js': {},
+        '@/utils/tools.js': { debounce: handler => handler },
+        '@/utils/cron.js': {},
+        'cron-parser-custom': {},
+      };
+      const values = createLoader(mocks)(file).default.data.call({ value: '*/5 * * * *' });
+      assert.equal(values.periodicCronImg, `/static/task-${language}.png`);
+    });
+  }
+}


### PR DESCRIPTION
STAG 发布后首页白屏。浏览器异常停在 Vue 给 `img` 设置 `src` 的位置：`Cannot convert object to primitive value`。调用栈对应 `Navigation`，实际传入值是包含 `default` 的 Module 对象；发布产物也确认导航 logo 的 `require` 结果被包装为 namespace。平台未提供自定义 logo 时，这条路径会使页面初始化失败。

将 11 个组件的图片引用改为默认 import，让模板始终接收图片 URL。覆盖导航、首页、空状态、异常提示、画布引导、凭证说明和定时配置；定时说明图继续按原 `i18n.t('task-zh')` 结果选择中英文，未改变业务逻辑或依赖版本。

本次接续 #885 发布后的排障，基于其合并提交 `5a068c0f`。出错的导航图片代码在 #885 前已存在；目前证据确认了本次产物的运行时故障，但没有确认是哪项构建依赖变化触发了 namespace 包装。

验证：

- 新增 10 项图片回归测试，执行真实组件 `data()`，模拟现场捕获的 Module 返回值；旧代码 10 项失败，修复后全部通过，包含中英文定时说明图。
- `npm run test:plugin-form` 全部通过；11 个修改的 Vue 文件 ESLint 和 `git diff --check` 通过；独立代码复核无阻塞问题。
- 完整生产构建仍被本地缺失的 `@blueking/bkflow-canvas-editor-vue2` 子路径和 `@blueking/crypto-js-sdk` 阻塞，4 项错误与修复前基线一致，不能视为构建通过。
- 本地 webpack 5.100.2 的简化构建没有复现现场 namespace 包装；上述回归是运行时边界测试，不代替发布产物的浏览器验收。
- 尚未部署、重启或回滚 STAG。合入并重新发布后，需要检查无自定义 logo 的首页、模板编辑、空状态及定时配置，确认控制台不再出现该渲染异常。

关联原任务：--bug=163214553
