### PR TITLE
fix(uniform_api): 兼容 V4 空 polling 配置 --story=137657966

### DIFF
--- a/bkflow/pipeline_plugins/query/uniform_api/utils.py
+++ b/bkflow/pipeline_plugins/query/uniform_api/utils.py
@@ -141,12 +141,15 @@ class UniformAPIClient(ApigwClientMixin, HttpRequestMixin):
         "required": ["id", "name", "url", "methods", "inputs"],
         "anyOf": [
             {
-                # v4.0.0 协议：要求完整的插件元信息；polling 为可选字段，仅当存在时校验其完整性
+                # v4.0.0 协议：要求完整的插件元信息；polling 缺省或空对象表示不轮询，非空时校验完整性
                 "properties": {
                     "wrapper_version": {"enum": ["v4.0.0"]},
                     "polling": {
                         "type": "object",
-                        "required": ["url", "task_tag_key", "success_tag", "fail_tag", "running_tag"],
+                        "anyOf": [
+                            {"maxProperties": 0},
+                            {"required": ["url", "task_tag_key", "success_tag", "fail_tag", "running_tag"]},
+                        ],
                         "properties": {
                             "url": {"type": "string"},
                             "task_tag_key": {"type": "string"},

--- a/docs/guide/api_plugin_v4.md
+++ b/docs/guide/api_plugin_v4.md
@@ -247,9 +247,16 @@ GET /open-plugins/open_plugin_001?version=1.2.0&source_key=sops&scope_type=biz&s
 | `forms` | object | 否 | 原生输入/输出表单描述；未提供时根据 `inputs/form_schema` 构造通用表单 |
 | `form_schema` | object | 否 | 通用 JSON Schema；存在 `properties` 时优先于 `inputs` 生成通用表单 |
 | `form_context` | object | 否 | 原生表单运行上下文 |
-| `polling` | object | 条件必填 | 使用轮询时必填 |
+| `polling` | object | 条件必填 | 使用轮询时必填；省略或返回 `{}` 表示不轮询 |
 | `callback` | object | 条件必填 | 使用回调时建议返回 `{"enabled": true}` |
 | `credential_key` | string | 否 | 执行、轮询和取消请求使用的凭证标识 |
+
+`polling` 的兼容规则：
+
+- 同步插件或仅依赖回调的插件可以省略 `polling`，也可以返回 `"polling": {}`，两者均表示不启用轮询。
+- 非空对象仍须完整包含 `url`、`task_tag_key`、`success_tag`、`fail_tag`、`running_tag`；三个状态标记须为包含 `key`、`value` 的对象，并满足各字段的类型约束。
+- 不接受 `null`、数组、字符串等非对象类型，也不接受仅含部分字段的非空配置。
+- 这项兼容不改变运行状态要求：仅回调时使用 `WAITING_CALLBACK`；返回 `CREATED` 或 `RUNNING` 仍必须提供完整的轮询配置。
 
 ## 7. 表单协议
 

--- a/tests/interface/plugin/services/test_uniform_api_meta.py
+++ b/tests/interface/plugin/services/test_uniform_api_meta.py
@@ -60,6 +60,25 @@ def test_extract_uniform_api_meta_data_returns_valid_v2_payload():
     assert data["inputs"][0]["key"] == "biz_id"
 
 
+@pytest.mark.parametrize("polling_fields", ({}, {"polling": {}}), ids=("omitted", "empty-object"))
+def test_extract_uniform_api_meta_data_returns_v4_without_polling(polling_fields):
+    """无轮询的 V4 插件详情应通过校验并原样返回。"""
+    meta = _meta_data(
+        wrapper_version="v4.0.0",
+        plugin_source="builtin",
+        plugin_code="job",
+        plugin_version="1.2.0",
+        outputs=[],
+        **polling_fields,
+    )
+
+    data = extract_uniform_api_meta_data(
+        _result(data=meta), requested_version="1.2.0", catalog_wrapper_version="v4.0.0"
+    )
+
+    assert data == meta
+
+
 def test_extract_uniform_api_meta_data_rejects_http_failure():
     """传输层失败不得当作成功 meta。"""
     with pytest.raises(UniformAPIMetaError, match="network failed"):

--- a/tests/plugins/components/collections/uniform_api_test/test_v4_0_0.py
+++ b/tests/plugins/components/collections/uniform_api_test/test_v4_0_0.py
@@ -1,6 +1,9 @@
 import ast
+import logging
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 from bkflow.pipeline_plugins.components.collections.uniform_api.v4_0_0 import (
     UniformAPIService,
@@ -150,20 +153,62 @@ class FakeParentData:
         return self.inputs.get(key, default)
 
 
-def test_open_plugin_sync_success_finishes_without_polling():
+@pytest.mark.parametrize("polling", (None, {}, {"url": "https://bk-sops.example/runs/status/"}))
+def test_open_plugin_sync_success_finishes_without_polling(polling):
+    """同步成功不依赖轮询配置，也不启动轮询。"""
     service = UniformAPIService()
     data = FakeData({})
 
     result = service._handle_open_plugin_status(
         data=data,
         status_data={"status": "SUCCEEDED", "outputs": {"value": "done"}},
-        polling={"url": "https://bk-sops.example/runs/status/"},
+        polling=polling,
         log_prefix="[uniform_api]",
     )
 
     assert result is True
     assert service.is_schedule_finished() is True
     assert data.outputs.data == {"value": "done"}
+    assert data.outputs.get("need_polling", False) is False
+
+
+@pytest.mark.parametrize("polling", (None, {}), ids=("omitted", "empty-object"))
+def test_open_plugin_waiting_callback_without_polling(polling):
+    """缺省或空轮询配置均只等待回调，不启用轮询兜底。"""
+    service = UniformAPIService()
+    data = FakeData({})
+
+    result = service._handle_open_plugin_status(
+        data=data,
+        status_data={"status": "WAITING_CALLBACK"},
+        polling=polling,
+        log_prefix="[uniform_api]",
+    )
+
+    assert result is True
+    assert service.interval is None
+    assert service.is_schedule_finished() is False
+    assert data.outputs.need_callback is True
+    assert data.outputs.need_polling is False
+
+
+@pytest.mark.parametrize("polling", (None, {}), ids=("omitted", "empty-object"))
+@pytest.mark.parametrize("status", ("CREATED", "RUNNING"))
+def test_open_plugin_running_without_polling_is_rejected(polling, status):
+    """兼容空 polling 不允许需要轮询的运行状态无配置地继续执行。"""
+    service = UniformAPIService()
+    service.setup_runtime_attrs(logger=logging.getLogger(__name__))
+    data = FakeData({})
+
+    result = service._handle_open_plugin_status(
+        data=data,
+        status_data={"status": status},
+        polling=polling,
+        log_prefix="[uniform_api]",
+    )
+
+    assert result is False
+    assert status in data.outputs.ex_data
     assert data.outputs.get("need_polling", False) is False
 
 

--- a/tests/plugins/uniform_api/test_uniform_api_client.py
+++ b/tests/plugins/uniform_api/test_uniform_api_client.py
@@ -31,6 +31,30 @@ from bkflow.pipeline_plugins.query.uniform_api.utils import (
 from bkflow.utils.api_client import HttpRequestResult
 
 
+@pytest.fixture
+def v4_meta():
+    """提供包含完整轮询配置的 V4 元数据。"""
+    return {
+        "id": "open_plugin_001",
+        "name": "JOB 执行作业",
+        "plugin_source": "builtin",
+        "plugin_code": "job_execute_task",
+        "plugin_version": "1.2.0",
+        "wrapper_version": "v4.0.0",
+        "url": "https://bk-sops.example/open-plugin-runs",
+        "methods": ["POST"],
+        "inputs": [],
+        "outputs": [],
+        "polling": {
+            "url": "https://bk-sops.example/open-plugin-runs/status",
+            "task_tag_key": "open_plugin_run_id",
+            "success_tag": {"key": "status", "value": "SUCCEEDED"},
+            "fail_tag": {"key": "status", "value": "FAILED"},
+            "running_tag": {"key": "status", "value": "RUNNING"},
+        },
+    }
+
+
 class TestUniformAPIClient:
     def setup_method(self, method):
         self.client = UniformAPIClient()
@@ -161,6 +185,60 @@ class TestUniformAPIClient:
 
         with pytest.raises(ValidationError):
             self.client.validate_response_data(invalid_instance, self.client.UNIFORM_API_META_RESPONSE_DATA_SCHEMA)
+
+    @pytest.mark.parametrize("polling_fields", ({}, {"polling": {}}), ids=("omitted", "empty-object"))
+    def test_validate_v4_detail_meta_without_polling(self, v4_meta, polling_fields):
+        """V4 未传 polling 或传空对象都表示不轮询。"""
+        v4_meta.pop("polling")
+        v4_meta.update(polling_fields)
+
+        self.client.validate_response_data(v4_meta, self.client.UNIFORM_API_META_RESPONSE_DATA_SCHEMA)
+
+    @pytest.mark.parametrize("missing_key", ("url", "task_tag_key", "success_tag", "fail_tag", "running_tag"))
+    def test_validate_v4_detail_meta_rejects_incomplete_polling(self, v4_meta, missing_key):
+        """V4 非空轮询配置仍须包含全部五个必填字段。"""
+        v4_meta["polling"].pop(missing_key)
+
+        with pytest.raises(ValidationError):
+            self.client.validate_response_data(v4_meta, self.client.UNIFORM_API_META_RESPONSE_DATA_SCHEMA)
+
+    @pytest.mark.parametrize("tag_key", ("success_tag", "fail_tag", "running_tag"))
+    @pytest.mark.parametrize("missing_key", ("key", "value"))
+    def test_validate_v4_detail_meta_rejects_incomplete_polling_tags(self, v4_meta, tag_key, missing_key):
+        """兼容空 polling 不得放宽非空配置内的状态标记校验。"""
+        v4_meta["polling"][tag_key].pop(missing_key)
+
+        with pytest.raises(ValidationError):
+            self.client.validate_response_data(v4_meta, self.client.UNIFORM_API_META_RESPONSE_DATA_SCHEMA)
+
+    @pytest.mark.parametrize(
+        "polling",
+        (None, [], "", False, {"unknown": True}),
+        ids=("null", "array", "string", "boolean", "unknown-field-only"),
+    )
+    def test_validate_v4_detail_meta_rejects_invalid_polling(self, v4_meta, polling):
+        """仅兼容空对象，不将其他假值或仅含未知字段的对象视为不轮询。"""
+        v4_meta["polling"] = polling
+
+        with pytest.raises(ValidationError):
+            self.client.validate_response_data(v4_meta, self.client.UNIFORM_API_META_RESPONSE_DATA_SCHEMA)
+
+    @pytest.mark.parametrize("wrapper_version", (None, "v2.0.0", "v3.0.0"))
+    @pytest.mark.parametrize("polling_fields", ({}, {"polling": {}}), ids=("omitted", "empty-object"))
+    def test_validate_legacy_detail_meta_without_polling(self, wrapper_version, polling_fields):
+        """旧协议省略 polling 或传空对象的兼容行为保持不变。"""
+        meta = {
+            "id": "api1",
+            "name": "test",
+            "url": "https://bk-sops.example/run/",
+            "methods": ["POST"],
+            "inputs": [],
+            **polling_fields,
+        }
+        if wrapper_version is not None:
+            meta["wrapper_version"] = wrapper_version
+
+        self.client.validate_response_data(meta, self.client.UNIFORM_API_META_RESPONSE_DATA_SCHEMA)
 
     def test_validate_v4_detail_meta_requires_complete_contract(self):
         invalid_instance = {


### PR DESCRIPTION
## 背景

#883 已恢复 V2/V3 对空 `polling` 的兼容，但 V4 插件详情返回 `"polling": {}` 时仍会被 Schema 校验拒绝，导致无轮询插件无法正常加载详情。V4 运行时已经把缺省或空对象视为不轮询，本次对齐元数据校验与运行语义。

## 修改

- 仅调整 V4 `polling` Schema：允许省略或 `{}`，表示不启用轮询。
- 非空对象仍要求 `url`、`task_tag_key`、`success_tag`、`fail_tag`、`running_tag`，保留原有嵌套必填字段和类型校验。
- 不接受 `null`、数组、字符串、布尔值或残缺的非空对象；V2/V3 行为保持不变。
- 补充 Schema、插件详情元数据解析、同步执行/仅回调/运行状态拒绝的回归测试，并更新 V4 接入文档。

## 验证

- 红绿验证：修复前，新增的 Schema 和详情解析空对象用例各失败 1 条；修复后通过。
- Interface 环境：`tests/plugins/uniform_api`、`tests/interface/plugin`、`tests/plugins/components/collections/uniform_api_test`，**277 passed**。
- Engine 环境：`tests/engine/task/test_open_plugin_snapshots.py`、`tests/engine/task/test_backfill_open_plugin_task_snapshots.py`，**9 passed**。
- 修改的 Python 文件通过 Flake8、Black（line-length=120）；`git diff --check` 通过。
- 本地使用 Python 3.9、仓库固定的 jsonschema 2.5.1 / bamboo-pipeline 3.29.10 / bamboo-engine 2.11.4；数据库相关测试使用隔离 SQLite 内存库和 `--nomigrations`。这不是全仓 MySQL CI 或环境验收结果，CI 以本 PR 检查为准。

## 影响范围

只放宽 V4 元数据中的空 `polling` 对象，不修改前端、执行/回调/轮询状态机、数据库模型或迁移。仅回调仍使用 `WAITING_CALLBACK`；返回 `CREATED` / `RUNNING` 仍须有完整轮询配置。未修改或部署业务环境。

关联单据沿用 #883：`--story=137657966`（uniform协议兼容polling修改）。
