### PR TITLE
fix(debug): 兼容子画布节点调试

### DIFF
--- a/bkflow/contrib/openapi/serializers.py
+++ b/bkflow/contrib/openapi/serializers.py
@@ -33,6 +33,7 @@ class EmptyBodySerializer(serializers.Serializer):
 class GetNodeDetailQuerySerializer(serializers.Serializer):
     username = serializers.CharField(required=False, default="")
     include_data = serializers.BooleanField(required=False, default=True)
+    include_loop_outputs = serializers.BooleanField(required=False, default=False)
     component_code = serializers.CharField(required=False)
     subprocess_stack = serializers.CharField(required=False, default="[]")
     loop = serializers.IntegerField(required=False)

--- a/bkflow/task/operations.py
+++ b/bkflow/task/operations.py
@@ -69,7 +69,7 @@ from bkflow.plugin.services.open_plugin_detect import (
     needs_start_validation,
 )
 from bkflow.task.context import SystemObject
-from bkflow.task.models import OpenPluginRunCallbackRef, TaskInstance
+from bkflow.task.models import OpenPluginRunCallbackRef, TaskFlowRelation, TaskInstance
 from bkflow.task.open_plugin_callback import (
     callback_token_digest,
     parse_open_plugin_callback_token,
@@ -329,6 +329,66 @@ class TaskOperation:
         self.task_instance = task_instance
         self.queue = queue
 
+    def _revoke_debug_descendants(self, operator: str, node_id: str = None):
+        """撤销 DEBUG 根任务创建的子画布/子流程任务，最深层子任务优先。"""
+        if self.task_instance.create_method != "DEBUG":
+            return
+
+        relations = list(
+            TaskFlowRelation.objects.filter(root_task_id=self.task_instance.id).values(
+                "task_id", "parent_task_id", "extra_info"
+            )
+        )
+        children_by_parent = {}
+        for relation in relations:
+            children_by_parent.setdefault(relation["parent_task_id"], []).append(relation)
+
+        direct_relations = children_by_parent.get(self.task_instance.id, [])
+        if node_id:
+            direct_relations = [
+                relation
+                for relation in direct_relations
+                if (relation.get("extra_info") or {}).get("node_id") == node_id
+            ]
+
+        descendants = []
+        pending = [(relation, 1) for relation in direct_relations]
+        visited = set()
+        while pending:
+            relation, depth = pending.pop(0)
+            task_id = relation["task_id"]
+            if task_id in visited:
+                continue
+            visited.add(task_id)
+            descendants.append((task_id, depth))
+            pending.extend((child, depth + 1) for child in children_by_parent.get(task_id, []))
+
+        active_tasks = {
+            task.id: task
+            for task in TaskInstance.objects.filter(
+                id__in=[task_id for task_id, _ in descendants],
+                is_finished=False,
+                is_revoked=False,
+                is_expired=False,
+                is_deleted=False,
+            )
+        }
+        for task_id, _ in sorted(descendants, key=lambda item: item[1], reverse=True):
+            child_task = active_tasks.get(task_id)
+            if child_task is None:
+                continue
+            result = TaskOperation(task_instance=child_task, queue=self.queue).revoke(
+                operator=operator,
+                cascade_debug_descendants=False,
+            )
+            if not result.result:
+                logger.warning(
+                    "[debug revoke] revoke child task failed, root_task_id=%s, child_task_id=%s, message=%s",
+                    self.task_instance.id,
+                    task_id,
+                    result.message,
+                )
+
     def _ensure_open_plugins_ready_for_start(self):
         """仅对包含开放插件快照或 V4 节点的任务请求 Interface 做启动预检。"""
         extra_info = self.task_instance.extra_info or {}
@@ -457,6 +517,8 @@ class TaskOperation:
         )
         if result.result:
             _dispatch_open_plugin_cancellation(task_id=self.task_instance.id, operator=operator)
+            if kwargs.get("cascade_debug_descendants", True):
+                self._revoke_debug_descendants(operator=operator)
         return result
 
     @uniform_task_operation_result
@@ -840,6 +902,10 @@ class TaskNodeOperation:
                 node_id=self.node_id,
                 operator=operator,
             )
+            TaskOperation(task_instance=self.task_instance)._revoke_debug_descendants(
+                operator=operator,
+                node_id=self.node_id,
+            )
         return result
 
     @trace_task_operation("get_node_detail", operation_type="task_node")
@@ -974,6 +1040,7 @@ class TaskNodeOperation:
         subprocess_stack: List[str],
         component_code: Optional[str] = None,
         loop: Optional[int] = None,
+        include_loop_outputs: bool = False,
         *args,
         **kwargs,
     ) -> OperationResult:
@@ -1028,7 +1095,7 @@ class TaskNodeOperation:
                     raw_outputs = hist[-1]["outputs"]
                     outputs_wrapper = {"outputs": raw_outputs, "ex_data": raw_outputs.get("ex_data")}
 
-            if settings.PLUGIN_LOOP_OUTPUTS_KEY in outputs_wrapper["outputs"]:
+            if not include_loop_outputs and settings.PLUGIN_LOOP_OUTPUTS_KEY in outputs_wrapper["outputs"]:
                 outputs_wrapper["outputs"].pop(settings.PLUGIN_LOOP_OUTPUTS_KEY)
 
         # 未执行节点需要实时渲染

--- a/bkflow/task/views.py
+++ b/bkflow/task/views.py
@@ -593,6 +593,7 @@ class TaskInstanceViewSet(
                 subprocess_stack=query_ser.validated_data.get("subprocess_stack"),
                 component_code=query_ser.validated_data.get("component_code"),
                 loop=query_ser.validated_data.get("loop"),
+                include_loop_outputs=query_ser.validated_data["include_loop_outputs"],
             )
             if not node_data_result.result:
                 return Response(dict(node_data_result))

--- a/bkflow/template/debug/dependency.py
+++ b/bkflow/template/debug/dependency.py
@@ -33,12 +33,17 @@ def _hash_obj(obj) -> str:
 
 
 def compute_node_config_hash(activity: dict) -> str:
-    """节点配置指纹：仅取影响执行的字段（type/component/optional），忽略坐标/备注"""
+    """节点配置指纹：仅取影响执行的字段，忽略坐标/备注。"""
     payload = {
         "type": activity.get("type"),
         "component": activity.get("component", {}),
         "optional": activity.get("optional"),
     }
+    if activity.get("type") == "SubCanvas":
+        payload["loop_config"] = activity.get("loop_config", {})
+        pipeline = activity.get("pipeline") or {}
+        payload["pipeline"] = compute_tree_fingerprint(pipeline)
+        payload["pipeline_outputs"] = pipeline.get("outputs", [])
     return _hash_obj(payload)
 
 
@@ -55,6 +60,27 @@ def _extract_referenced_var_keys(value) -> Set[str]:
         return {"${%s}" % ref for ref in ConstantTemplate(safe_value).get_reference()}
     except Exception:
         return set()
+
+
+def get_activity_referenced_var_keys(activity: dict) -> Set[str]:
+    """提取节点执行时会消费的父画布变量。"""
+    referenced_vars: Set[str] = set()
+    component_data = activity.get("component", {}).get("data", {})
+    for field in component_data.values():
+        value = field.get("value") if isinstance(field, dict) else field
+        referenced_vars |= _extract_referenced_var_keys(value)
+
+    if activity.get("type") != "SubCanvas":
+        return referenced_vars
+
+    loop_params = activity.get("loop_config", {}).get("loop_params", {})
+    referenced_vars |= _extract_referenced_var_keys(loop_params)
+    inner_constants = (activity.get("pipeline") or {}).get("constants", {})
+    for constant in inner_constants.values():
+        if constant.get("show_type") != "show" or not constant.get("need_render", True):
+            continue
+        referenced_vars |= _extract_referenced_var_keys(constant.get("value"))
+    return referenced_vars
 
 
 def compute_tree_fingerprint(pipeline_tree: dict) -> dict:
@@ -99,10 +125,7 @@ def build_dependency_graph(pipeline_tree: dict) -> dict:
 
     data: Dict[str, Set[str]] = {nid: set() for nid in node_ids}
     for nid, act in activities.items():
-        component_data = act.get("component", {}).get("data", {})
-        referenced_vars: Set[str] = set()
-        for field in component_data.values():
-            referenced_vars |= _extract_referenced_var_keys(field.get("value"))
+        referenced_vars = get_activity_referenced_var_keys(act)
         producers = {var_producer[var_key] for var_key in referenced_vars if var_key in var_producer}
         for producer in producers:
             if producer in data and producer != nid:

--- a/bkflow/template/debug/service.py
+++ b/bkflow/template/debug/service.py
@@ -32,6 +32,7 @@ from bkflow.template.debug.dependency import (
     build_dependency_graph,
     closure,
     compute_tree_fingerprint,
+    get_activity_referenced_var_keys,
 )
 from bkflow.template.debug.gateway import (
     DEBUGGABLE_GATEWAY_TYPES,
@@ -257,18 +258,31 @@ class DebugService:
             for key, info in classified["data_inputs"].items()
             if info.get("type") == "splice" and info.get("source_act")
         }
-        component_data = act.get("component", {}).get("data", {})
+        referenced_vars = get_activity_referenced_var_keys(act)
         missing = []
-        for field in component_data.values():
-            value = field.get("value")
-            if not isinstance(value, str):
-                continue
-            for var_key, producer in produced.items():
-                if var_key in value and var_key not in (ctx.global_vars or {}):
-                    item = {"key": var_key, "source_node_id": producer}
-                    if item not in missing:
-                        missing.append(item)
+        for var_key, producer in produced.items():
+            if var_key in referenced_vars and var_key not in (ctx.global_vars or {}):
+                missing.append({"key": var_key, "source_node_id": producer})
         return (len(missing) == 0), missing
+
+    @staticmethod
+    def _pipeline_contains_debug_node(pipeline_tree, node_id):
+        if node_id in pipeline_tree.get("activities", {}) or node_id in pipeline_tree.get("gateways", {}):
+            return True
+        for activity in pipeline_tree.get("activities", {}).values():
+            if activity.get("type") != "SubCanvas" or not activity.get("pipeline"):
+                continue
+            if DebugService._pipeline_contains_debug_node(activity["pipeline"], node_id):
+                return True
+        return False
+
+    def _find_subcanvas_parent(self, node_id):
+        for subcanvas_id, activity in self.pipeline_tree.get("activities", {}).items():
+            if activity.get("type") != "SubCanvas" or not activity.get("pipeline"):
+                continue
+            if self._pipeline_contains_debug_node(activity["pipeline"], node_id):
+                return subcanvas_id
+        return None
 
     # ---- 内部工具 ----
     def _refresh_tree_fingerprint(self, ctx: DebugContext):
@@ -605,7 +619,11 @@ class DebugService:
             observed_statuses.append(ns.status)
             ns.duration_ms = int((child.get("elapsed_time") or 0) * 1000)
             if ns.status in ("finished", "failed"):
-                detail = client.get_task_node_detail(task_id, runtime_id, data={"include_data": True})
+                detail = client.get_task_node_detail(
+                    task_id,
+                    runtime_id,
+                    data={"include_data": True, "include_loop_outputs": True},
+                )
                 ddata = detail.get("data", {}) if detail.get("result") else {}
                 version = ddata.get("version") or ddata.get("history_id") or "v1"
                 ns.log_ref = {"instance_id": task_id, "node_id": runtime_id, "version": version}
@@ -667,7 +685,11 @@ class DebugService:
             for runtime_id, child in children.items():
                 if child.get("state") != "FAILED" or runtime_errors.get(runtime_id) or state_errors.get(runtime_id):
                     continue
-                detail = client.get_task_node_detail(task_id, runtime_id, data={"include_data": True})
+                detail = client.get_task_node_detail(
+                    task_id,
+                    runtime_id,
+                    data={"include_data": True, "include_loop_outputs": True},
+                )
                 ddata = detail.get("data", {}) if detail.get("result") else {}
                 if ddata.get("ex_data"):
                     runtime_errors[runtime_id] = ddata["ex_data"]
@@ -927,6 +949,15 @@ class DebugService:
         try:
             ns = DebugNodeState.objects.get(debug_context=ctx, node_id=node_id)
         except DebugNodeState.DoesNotExist:
+            subcanvas_node_id = self._find_subcanvas_parent(node_id)
+            if subcanvas_node_id:
+                raise DebugStateError(
+                    {
+                        "detail": "暂不支持子画布内部节点单步调试",
+                        "node_id": node_id,
+                        "subcanvas_node_id": subcanvas_node_id,
+                    }
+                )
             raise DebugStateError({"detail": "节点不存在", "node_id": node_id})
         effective_mode = mode or ns.execution_mode
 

--- a/tests/engine/task/test_debug_create_instance.py
+++ b/tests/engine/task/test_debug_create_instance.py
@@ -67,6 +67,35 @@ class TestDebugCreateInstance:
         )
         assert TaskContext(instance).is_mock is True
 
+    def test_debug_subcanvas_mock_maps_container_node_and_aggregate_output(self):
+        pipeline_tree = build_default_pipeline_tree()
+        node_id = list(pipeline_tree[PE.activities].keys())[0]
+        original_node = pipeline_tree[PE.activities][node_id]
+        pipeline_tree[PE.activities][node_id] = {
+            "id": node_id,
+            "name": "loop canvas",
+            "type": "SubCanvas",
+            "incoming": original_node["incoming"],
+            "outgoing": original_node["outgoing"],
+            "optional": True,
+            "loop_config": {"enable": True, "type": "time_loop", "loop_times": 2, "loop_params": {}},
+            "pipeline": build_default_pipeline_tree(),
+        }
+        aggregate = [{"result": "first"}, {"result": "second"}]
+
+        instance = TaskInstance.objects.create_instance(
+            pipeline_tree=pipeline_tree,
+            space_id=10,
+            create_method="DEBUG",
+            creator="admin",
+            mock_data={"nodes": [node_id], "outputs": {node_id: {"outputs": aggregate}}},
+        )
+
+        mock = TaskMockData.objects.get(taskflow_id=instance.id)
+        assert len(mock.data["nodes"]) == 1
+        runtime_node_id = mock.data["nodes"][0]
+        assert mock.data["outputs"][runtime_node_id] == {"outputs": aggregate}
+
 
 class TestShouldKeepDebugTasks:
     """不打数据库，用真实 QueryDict 覆盖 apply_token 的查询串。"""

--- a/tests/engine/task/test_node_operations.py
+++ b/tests/engine/task/test_node_operations.py
@@ -23,9 +23,11 @@ from unittest import mock
 import pytest
 from bamboo_engine import states as bamboo_engine_states
 from bamboo_engine.api import EngineAPIResult
+from django.conf import settings
 from django.utils import timezone
 
-from bkflow.task.models import OpenPluginRunCallbackRef, TaskInstance
+from bkflow.constants import TaskTriggerMethod
+from bkflow.task.models import OpenPluginRunCallbackRef, TaskFlowRelation, TaskInstance
 from bkflow.task.open_plugin_callback import (
     callback_token_digest,
     issue_open_plugin_callback_token,
@@ -52,6 +54,79 @@ class TestTaskNodeOperation:
         if not node_ids:
             pytest.skip("No nodes in pipeline tree")
         return task_instance, node_ids[0]
+
+    def test_get_node_data_can_preserve_loop_outputs_for_debug_sync(self, mocker):
+        task_instance, node_id = self._create_task_instance_with_node()
+        node_operation = TaskNodeOperation(task_instance, node_id)
+        aggregate = [{"result": "first"}, {"result": "second"}]
+        mocker.patch(
+            "bamboo_engine.api.get_children_states",
+            return_value=EngineAPIResult(result=True, data={node_id: {"loop": 1}}, message="success"),
+        )
+        mocker.patch(
+            "bamboo_engine.api.get_execution_data",
+            return_value=EngineAPIResult(
+                result=True,
+                data={
+                    "inputs": {},
+                    "outputs": {settings.PLUGIN_LOOP_OUTPUTS_KEY: aggregate, "ex_data": ""},
+                },
+                message="success",
+            ),
+        )
+        mocker.patch.object(
+            node_operation,
+            "_get_node_info",
+            return_value={"type": "ServiceActivity", "component": {"code": "subcanvas_plugin"}},
+        )
+        format_outputs = mocker.patch.object(
+            node_operation,
+            "_format_outputs",
+            return_value=(
+                True,
+                "",
+                [{"key": settings.PLUGIN_LOOP_OUTPUTS_KEY, "value": aggregate}],
+            ),
+        )
+
+        result = node_operation.get_node_data(
+            username="admin",
+            subprocess_stack=[],
+            include_loop_outputs=True,
+        )
+
+        assert result.result is True
+        assert result.data["outputs"] == [{"key": settings.PLUGIN_LOOP_OUTPUTS_KEY, "value": aggregate}]
+        formatted_raw_outputs = format_outputs.call_args.kwargs["outputs"]["outputs"]
+        assert formatted_raw_outputs[settings.PLUGIN_LOOP_OUTPUTS_KEY] == aggregate
+
+    def test_get_node_data_hides_loop_outputs_by_default(self, mocker):
+        task_instance, node_id = self._create_task_instance_with_node()
+        node_operation = TaskNodeOperation(task_instance, node_id)
+        mocker.patch(
+            "bamboo_engine.api.get_children_states",
+            return_value=EngineAPIResult(result=True, data={node_id: {"loop": 1}}, message="success"),
+        )
+        mocker.patch(
+            "bamboo_engine.api.get_execution_data",
+            return_value=EngineAPIResult(
+                result=True,
+                data={"inputs": {}, "outputs": {settings.PLUGIN_LOOP_OUTPUTS_KEY: ["hidden"], "ex_data": ""}},
+                message="success",
+            ),
+        )
+        mocker.patch.object(
+            node_operation,
+            "_get_node_info",
+            return_value={"type": "ServiceActivity", "component": {"code": "subcanvas_plugin"}},
+        )
+        format_outputs = mocker.patch.object(node_operation, "_format_outputs", return_value=(True, "", []))
+
+        result = node_operation.get_node_data(username="admin", subprocess_stack=[])
+
+        assert result.result is True
+        formatted_raw_outputs = format_outputs.call_args.kwargs["outputs"]["outputs"]
+        assert settings.PLUGIN_LOOP_OUTPUTS_KEY not in formatted_raw_outputs
 
     def _create_open_plugin_callback_ref(
         self,
@@ -442,6 +517,42 @@ class TestTaskNodeOperation:
         cancel_open_plugin_runs.assert_called_once_with(
             task_id=task_instance.id, node_id=node_id, operator="test_operator"
         )
+
+    def test_debug_subcanvas_forced_fail_revokes_its_active_child_task(self, mocker):
+        task_instance, node_id = self._create_task_instance_with_node()
+        task_instance.create_method = "DEBUG"
+        task_instance.save(update_fields=["create_method"])
+        child = TaskInstance.objects.create_instance(
+            space_id=1,
+            pipeline_tree=build_default_pipeline_tree(),
+            trigger_method=TaskTriggerMethod.sub_canvas.name,
+            creator="admin",
+        )
+        child.is_started = True
+        child.save(update_fields=["is_started"])
+        TaskFlowRelation.objects.create(
+            task_id=child.id,
+            parent_task_id=task_instance.id,
+            root_task_id=task_instance.id,
+            extra_info={"node_id": node_id, "trigger_method": TaskTriggerMethod.sub_canvas.name},
+        )
+        mocker.patch(
+            "bamboo_engine.api.forced_fail_activity",
+            return_value=EngineAPIResult(result=True, message="success"),
+        )
+        revoke_pipeline = mocker.patch(
+            "bamboo_engine.api.revoke_pipeline",
+            return_value=EngineAPIResult(result=True, message="success"),
+        )
+        mocker.patch("bkflow.task.operations._dispatch_open_plugin_cancellation")
+
+        result = TaskNodeOperation(task_instance, node_id).forced_fail(
+            operator="admin",
+            suppress_failure_side_effects=True,
+        )
+
+        assert result.result is True
+        revoke_pipeline.assert_called_once_with(runtime=mock.ANY, pipeline_id=child.instance_id)
 
     def test_forced_fail_on_mock_task_does_not_suppress_side_effects(self, mocker):
         """存量 MOCK 任务 forced_fail 不屏蔽失败副作用，但仍取消开放插件。"""

--- a/tests/engine/task/test_task_operations.py
+++ b/tests/engine/task/test_task_operations.py
@@ -26,7 +26,8 @@ from opentelemetry.sdk.trace import TracerProvider
 from pipeline.eri.models import Schedule as DBSchedule
 from pipeline.utils.uniqid import node_uniqid
 
-from bkflow.task.models import TaskInstance
+from bkflow.constants import TaskTriggerMethod
+from bkflow.task.models import TaskFlowRelation, TaskInstance
 from bkflow.task.operations import OperationResult, TaskOperation
 from bkflow.utils.pipeline import build_default_pipeline_tree
 
@@ -89,6 +90,50 @@ class TestTaskOperationComplete:
         )
         result = task_operation.get_task_states()
         assert "state" in result.data
+
+    def test_debug_task_revoke_cascades_to_active_subcanvas_descendants(self, mocker):
+        root = TaskInstance.objects.create_instance(
+            space_id=1,
+            pipeline_tree=build_default_pipeline_tree(),
+            create_method="DEBUG",
+            creator="admin",
+        )
+        child = TaskInstance.objects.create_instance(
+            space_id=1,
+            pipeline_tree=build_default_pipeline_tree(),
+            trigger_method=TaskTriggerMethod.sub_canvas.name,
+            creator="admin",
+        )
+        grandchild = TaskInstance.objects.create_instance(
+            space_id=1,
+            pipeline_tree=build_default_pipeline_tree(),
+            trigger_method=TaskTriggerMethod.sub_canvas.name,
+            creator="admin",
+        )
+        TaskInstance.objects.filter(id__in=[root.id, child.id, grandchild.id]).update(is_started=True)
+        TaskFlowRelation.objects.create(
+            task_id=child.id,
+            parent_task_id=root.id,
+            root_task_id=root.id,
+            extra_info={"node_id": "S", "trigger_method": TaskTriggerMethod.sub_canvas.name},
+        )
+        TaskFlowRelation.objects.create(
+            task_id=grandchild.id,
+            parent_task_id=child.id,
+            root_task_id=root.id,
+            extra_info={"node_id": "nested-S", "trigger_method": TaskTriggerMethod.sub_canvas.name},
+        )
+        revoke_pipeline = mocker.patch(
+            "bamboo_engine.api.revoke_pipeline",
+            return_value=EngineAPIResult(result=True, message="success"),
+        )
+        mocker.patch("bkflow.task.operations._dispatch_open_plugin_cancellation")
+
+        result = TaskOperation(root).revoke(operator="admin")
+
+        assert result.result is True
+        revoked_pipeline_ids = [call.kwargs["pipeline_id"] for call in revoke_pipeline.call_args_list]
+        assert revoked_pipeline_ids == [root.instance_id, grandchild.instance_id, child.instance_id]
 
     def test_render_current_constants_not_running(self, mocker):
         """测试渲染当前常量，任务未运行"""

--- a/tests/engine/task/test_task_views.py
+++ b/tests/engine/task/test_task_views.py
@@ -1222,6 +1222,50 @@ class TestTaskInstanceViewSet:
             assert response.data["data"]["x"] == 1
             assert response.data["data"]["y"] == 2
 
+    def test_get_node_detail_forwards_include_loop_outputs(self):
+        """调试同步可显式读取循环聚合输出，普通任务详情默认行为不变。"""
+
+        from rest_framework.request import Request
+
+        class _Result(dict):
+            def __init__(self, result=True, data=None, message="success"):
+                super().__init__({"result": result, "data": data, "message": message})
+                self.result = result
+                self.data = data
+                self.message = message
+
+        pipeline_tree = build_default_pipeline_tree()
+        task_instance = TaskInstance.objects.create_instance(space_id=1, pipeline_tree=pipeline_tree)
+        node_id = list(pipeline_tree["activities"].keys())[0]
+
+        with patch("bkflow.task.views.TaskNodeOperation") as mock_node_operation:
+            mock_node_op = MagicMock()
+            mock_node_op.get_node_data.return_value = _Result(result=True, data={})
+            mock_node_op.get_node_detail.return_value = _Result(result=True, data={})
+            mock_node_operation.return_value = mock_node_op
+            view = TaskInstanceViewSet()
+            view.action = "get_node_detail"
+            view.kwargs = {"pk": task_instance.id}
+            view.get_object = MagicMock(return_value=task_instance)
+            raw_request = self._create_request_with_auth(
+                "get",
+                f"/task/{task_instance.id}/get_task_node_detail/{node_id}/",
+                {"include_data": True, "include_loop_outputs": True},
+            )
+            request = Request(raw_request)
+            view.request = request
+
+            response = TaskInstanceViewSet.get_node_detail.__wrapped__(view, request, node_id=node_id)
+
+            assert response.status_code == status.HTTP_200_OK
+            mock_node_op.get_node_data.assert_called_once_with(
+                username="",
+                subprocess_stack=[],
+                component_code=None,
+                loop=None,
+                include_loop_outputs=True,
+            )
+
     @patch("bkflow.task.views.TaskOperation")
     def test_get_states_forwards_optional_debug_details(self, mock_task_operation):
         task_instance = TaskInstance.objects.create(name="debug task", space_id=1, instance_id="root", is_started=True)

--- a/tests/interface/template/debug/test_can_step.py
+++ b/tests/interface/template/debug/test_can_step.py
@@ -46,6 +46,38 @@ TREE = {
     },
 }
 
+SUBCANVAS_TREE = {
+    "activities": {
+        "A": {"id": "A", "type": "ServiceActivity", "component": {"code": "t", "data": {}}},
+        "S": {
+            "id": "S",
+            "type": "SubCanvas",
+            "loop_config": {
+                "enable": True,
+                "type": "array_loop",
+                "loop_times": None,
+                "loop_params": {"${loop_item}": "${g1}"},
+            },
+            "pipeline": {
+                "activities": {},
+                "flows": {},
+                "gateways": {},
+                "constants": {
+                    "${inner_input}": {
+                        "key": "${inner_input}",
+                        "show_type": "show",
+                        "need_render": True,
+                        "value": {"items": ["${g1}"]},
+                    }
+                },
+            },
+        },
+    },
+    "flows": {},
+    "gateways": {},
+    "constants": TREE["constants"],
+}
+
 
 @pytest.mark.django_db
 class TestCanStep:
@@ -65,3 +97,17 @@ class TestCanStep:
         ctx.save()
         can2, missing2 = svc.compute_can_step(ctx, "B")
         assert can2 is True and missing2 == []
+
+    def test_subcanvas_blocked_until_loop_and_inner_dependencies_exist(self):
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=SUBCANVAS_TREE)
+        ctx = svc.get_or_create_context()
+
+        can, missing = svc.compute_can_step(ctx, "S")
+
+        assert can is False
+        assert missing == [{"key": "${g1}", "source_node_id": "A"}]
+
+        ctx.global_vars = {"${g1}": ["first", "second"]}
+        ctx.save(update_fields=["global_vars"])
+
+        assert svc.compute_can_step(ctx, "S") == (True, [])

--- a/tests/interface/template/debug/test_dependency.py
+++ b/tests/interface/template/debug/test_dependency.py
@@ -108,3 +108,66 @@ class TestDependency:
         graph = build_dependency_graph(pipeline)
         # 数据流：A 产出 ${g1}，C 在嵌套列表中消费 -> A -> C
         assert "C" in graph["data"]["A"]
+
+    def test_subcanvas_config_hash_tracks_inner_pipeline_and_loop_config(self):
+        subcanvas = {
+            "id": "S",
+            "type": "SubCanvas",
+            "optional": True,
+            "loop_config": {"enable": True, "type": "time_loop", "loop_times": 2},
+            "pipeline": {
+                "activities": {
+                    "I": {
+                        "id": "I",
+                        "type": "ServiceActivity",
+                        "component": {"code": "test", "data": {"x": {"hook": False, "value": "1"}}},
+                    }
+                },
+                "flows": {},
+                "gateways": {},
+                "constants": {},
+                "outputs": [],
+            },
+        }
+        original_hash = compute_node_config_hash(subcanvas)
+
+        inner_changed = copy.deepcopy(subcanvas)
+        inner_changed["pipeline"]["activities"]["I"]["component"]["data"]["x"]["value"] = "2"
+        loop_changed = copy.deepcopy(subcanvas)
+        loop_changed["loop_config"]["loop_times"] = 3
+        outputs_changed = copy.deepcopy(subcanvas)
+        outputs_changed["pipeline"]["outputs"] = ["${inner_output}"]
+
+        assert compute_node_config_hash(inner_changed) != original_hash
+        assert compute_node_config_hash(loop_changed) != original_hash
+        assert compute_node_config_hash(outputs_changed) != original_hash
+
+    def test_subcanvas_references_create_data_edges(self):
+        pipeline = copy.deepcopy(PIPELINE)
+        pipeline["activities"]["S"] = {
+            "id": "S",
+            "type": "SubCanvas",
+            "loop_config": {
+                "enable": True,
+                "type": "array_loop",
+                "loop_times": None,
+                "loop_params": {"${loop_item}": "${g1}"},
+            },
+            "pipeline": {
+                "activities": {},
+                "flows": {},
+                "gateways": {},
+                "constants": {
+                    "${inner_input}": {
+                        "key": "${inner_input}",
+                        "show_type": "show",
+                        "need_render": True,
+                        "value": {"nested": ["${g1}"]},
+                    }
+                },
+            },
+        }
+
+        graph = build_dependency_graph(pipeline)
+
+        assert "S" in graph["data"]["A"]

--- a/tests/interface/template/debug/test_service_global_run.py
+++ b/tests/interface/template/debug/test_service_global_run.py
@@ -29,6 +29,20 @@ PIPELINE = {
     "constants": {},
 }
 
+PIPELINE_SUBCANVAS = {
+    "activities": {
+        "S": {
+            "id": "S",
+            "type": "SubCanvas",
+            "loop_config": {"enable": True, "type": "time_loop", "loop_times": 2, "loop_params": {}},
+            "pipeline": {"activities": {}, "flows": {}, "gateways": {}, "constants": {}, "outputs": []},
+        }
+    },
+    "flows": {},
+    "gateways": {},
+    "constants": {},
+}
+
 
 def _create_task_payload(client):
     call = client.create_task.call_args
@@ -166,3 +180,28 @@ class TestGlobalRun:
         sent = _create_task_payload(client)
         assert sent["mock_data"]["fail_nodes"] == ["A"]
         assert sent["mock_data"]["errors"] == {"A": "boom"}
+
+    def test_global_run_can_mock_subcanvas_container(self, mocker):
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=PIPELINE_SUBCANVAS)
+        client = mocker.MagicMock()
+        client.create_task.return_value = {"result": True, "data": {"id": 456}, "message": ""}
+        client.operate_task.return_value = {"result": True, "data": {}, "message": ""}
+        mocker.patch.object(svc, "_task_client", return_value=client)
+        svc.sync_node_states()
+        svc.node_mock(
+            node_id="S",
+            enable=True,
+            mock_result="success",
+            mock_outputs={"outputs": [{"result": "mocked"}]},
+        )
+
+        svc.global_run(inputs={}, operator="admin")
+
+        sent = _create_task_payload(client)
+        assert sent["pipeline_tree"]["activities"]["S"]["type"] == "SubCanvas"
+        assert sent["mock_data"] == {
+            "nodes": ["S"],
+            "outputs": {"S": {"outputs": [{"result": "mocked"}]}},
+            "fail_nodes": [],
+            "errors": {},
+        }

--- a/tests/interface/template/debug/test_service_sync.py
+++ b/tests/interface/template/debug/test_service_sync.py
@@ -40,6 +40,31 @@ PIPELINE = {
     },
 }
 
+PIPELINE_SUBCANVAS = {
+    "activities": {
+        "S": {
+            "id": "S",
+            "type": "SubCanvas",
+            "loop_config": {"enable": True, "type": "time_loop", "loop_times": 2, "loop_params": {}},
+            "pipeline": {"activities": {}, "flows": {}, "gateways": {}, "constants": {}, "outputs": []},
+        }
+    },
+    "flows": {},
+    "gateways": {},
+    "constants": {
+        "${outputs}": {
+            "key": "${outputs}",
+            "name": "loop outputs",
+            "show_type": "hide",
+            "value": [],
+            "source_type": "component_outputs",
+            "custom_type": "array",
+            "source_tag": "",
+            "source_info": {"S": ["outputs"]},
+        }
+    },
+}
+
 PIPELINE_GATEWAY = {
     "activities": {},
     "flows": {
@@ -133,6 +158,41 @@ class TestSyncFromDebugTask:
         assert ctx.last_run_type == "global"
         assert ctx.last_run_status == "finished"
         assert ctx.last_error_detail == {}
+
+    def test_sync_subcanvas_preserves_aggregate_loop_outputs(self, mocker):
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=PIPELINE_SUBCANVAS)
+        ctx = svc.sync_node_states()
+        ctx.status = "running"
+        ctx.active_task_id = 456
+        ctx.active_run_type = "step"
+        ctx.active_node_id = "S"
+        ctx.save()
+        aggregate = [{"result": "first"}, {"result": "second"}]
+        client = mocker.MagicMock()
+        client.get_task_states.return_value = {
+            "result": True,
+            "data": {"state": "FINISHED", "children": {"rtS": {"state": "FINISHED", "elapsed_time": 1}}},
+            "message": "",
+        }
+        client.get_node_id_map.return_value = {"result": True, "data": {"S": "rtS"}, "message": ""}
+        client.get_task_node_detail.return_value = {
+            "result": True,
+            "data": {"outputs": [{"key": "outputs", "value": aggregate}], "version": "v1"},
+            "message": "",
+        }
+        mocker.patch.object(svc, "_task_client", return_value=client)
+
+        svc.sync_from_debug_task(ctx)
+
+        node_state = DebugNodeState.objects.get(debug_context=ctx, node_id="S")
+        ctx.refresh_from_db()
+        assert node_state.outputs == {"outputs": aggregate}
+        assert ctx.global_vars["${outputs}"] == aggregate
+        client.get_task_node_detail.assert_called_once_with(
+            456,
+            "rtS",
+            data={"include_data": True, "include_loop_outputs": True},
+        )
 
     def test_sync_running_task_does_not_release_lock(self, mocker):
         """任务运行中：回写节点态与耗时，但不释放锁"""
@@ -372,7 +432,11 @@ class TestSyncFromDebugTask:
         gateway = DebugNodeState.objects.get(debug_context=ctx, node_id="G")
         assert gateway.status == "failed"
         assert gateway.error_detail == {"type": "runtime", "message": "multiple conditions meet"}
-        client.get_task_node_detail.assert_called_once_with(456, "rt_gateway", data={"include_data": True})
+        client.get_task_node_detail.assert_called_once_with(
+            456,
+            "rt_gateway",
+            data={"include_data": True, "include_loop_outputs": True},
+        )
 
     def test_sync_finished_gateway_persists_selected_flows(self, mocker):
         svc = DebugService(template_id=1, space_id=10, pipeline_tree=PIPELINE_GATEWAY)

--- a/tests/interface/template/debug/test_step_run.py
+++ b/tests/interface/template/debug/test_step_run.py
@@ -118,6 +118,70 @@ TREE_CONTROL_GATEWAYS = {
     "constants": {},
 }
 
+TREE_SUBCANVAS = {
+    "start_event": {"id": "start", "type": "EmptyStartEvent", "incoming": None, "outgoing": "f1"},
+    "end_event": {"id": "end", "type": "EmptyEndEvent", "incoming": "f2", "outgoing": None},
+    "activities": {
+        "S": {
+            "id": "S",
+            "name": "loop canvas",
+            "type": "SubCanvas",
+            "incoming": "f1",
+            "outgoing": "f2",
+            "optional": True,
+            "loop_config": {"enable": True, "type": "time_loop", "loop_times": 2, "loop_params": {}},
+            "pipeline": {
+                "start_event": {
+                    "id": "inner_start",
+                    "type": "EmptyStartEvent",
+                    "incoming": None,
+                    "outgoing": "inner_f1",
+                },
+                "end_event": {
+                    "id": "inner_end",
+                    "type": "EmptyEndEvent",
+                    "incoming": "inner_f2",
+                    "outgoing": None,
+                },
+                "activities": {
+                    "I": {
+                        "id": "I",
+                        "type": "ServiceActivity",
+                        "incoming": "inner_f1",
+                        "outgoing": "inner_f2",
+                        "component": {"code": "t", "data": {}},
+                    }
+                },
+                "flows": {
+                    "inner_f1": {"id": "inner_f1", "source": "inner_start", "target": "I"},
+                    "inner_f2": {"id": "inner_f2", "source": "I", "target": "inner_end"},
+                },
+                "gateways": {},
+                "constants": {},
+                "outputs": [],
+            },
+        }
+    },
+    "flows": {
+        "f1": {"id": "f1", "source": "start", "target": "S"},
+        "f2": {"id": "f2", "source": "S", "target": "end"},
+    },
+    "gateways": {},
+    "constants": {
+        "${outputs}": {
+            "key": "${outputs}",
+            "name": "loop outputs",
+            "show_type": "hide",
+            "value": [],
+            "source_type": "component_outputs",
+            "source_info": {"S": ["outputs"]},
+            "custom_type": "array",
+            "source_tag": "",
+        }
+    },
+    "outputs": [],
+}
+
 
 @pytest.mark.django_db
 class TestStepRunAndMock:
@@ -228,6 +292,64 @@ class TestStepRunAndMock:
         assert ctx.global_vars["${g1}"] == "produced"
         ns = DebugNodeState.objects.get(debug_context=ctx, node_id="A")
         assert ns.status == "finished" and ns.log_ref in (None, {})
+
+    def test_subcanvas_step_mock_writes_aggregate_output(self):
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=TREE_SUBCANVAS)
+        ctx = svc.sync_node_states()
+        aggregate = [{"result": "first"}, {"result": "second"}]
+
+        result = svc.step_run(
+            node_id="S",
+            operator="admin",
+            mode="mock",
+            mock_result="success",
+            mock_outputs={"outputs": aggregate},
+        )
+
+        assert result["status"] == "finished"
+        assert result["outputs"] == {"outputs": aggregate}
+        ctx.refresh_from_db()
+        assert ctx.global_vars["${outputs}"] == aggregate
+
+    def test_subcanvas_real_step_runs_the_container_as_one_node(self, mocker):
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=TREE_SUBCANVAS)
+        svc.sync_node_states()
+        client = mocker.MagicMock()
+        client.create_task.return_value = {"result": True, "data": {"id": 789}, "message": ""}
+        client.get_node_id_map.return_value = {"result": True, "data": {"S": "rtS"}, "message": ""}
+        client.operate_task.return_value = {"result": True, "data": {}, "message": ""}
+        mocker.patch.object(svc, "_task_client", return_value=client)
+
+        result = svc.step_run(node_id="S", operator="admin", mode="real")
+
+        assert result["status"] == "running"
+        create_payload = client.create_task.call_args.args[0]
+        subcanvas = create_payload["pipeline_tree"]["activities"]["S"]
+        assert subcanvas["type"] == "SubCanvas"
+        assert set(subcanvas["pipeline"]["activities"]) == {"I"}
+        assert create_payload["create_method"] == "DEBUG"
+
+    def test_subcanvas_inner_node_step_is_explicitly_unsupported(self):
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=TREE_SUBCANVAS)
+        svc.sync_node_states()
+
+        with pytest.raises(DebugStateError) as exc_info:
+            svc.step_run(node_id="I", operator="admin", mode="real")
+
+        assert exc_info.value.args[0] == {
+            "detail": "暂不支持子画布内部节点单步调试",
+            "node_id": "I",
+            "subcanvas_node_id": "S",
+        }
+
+    def test_subcanvas_context_exposes_only_container_as_debuggable_node(self):
+        svc = DebugService(template_id=1, space_id=10, pipeline_tree=TREE_SUBCANVAS)
+
+        context_view = svc.build_context_view()
+
+        assert [node["node_id"] for node in context_view["nodes"]] == ["S"]
+        assert context_view["nodes"][0]["supports_step"] is True
+        assert context_view["nodes"][0]["supports_mock"] is True
 
     def test_step_run_mock_fail_sets_failed_no_writeback(self):
         svc = DebugService(template_id=1, space_id=10, pipeline_tree=TREE)


### PR DESCRIPTION
## 背景

子画布接入单步/全局调试后，存在以下兼容问题：

- 调试终止只停止父任务，子画布已经创建的独立子任务仍可能继续运行。
- 单步依赖判断和配置指纹未覆盖子画布循环参数、内部输入及内部流程配置。
- 子画布循环聚合输出在节点详情层被默认过滤，真实调试结果无法回写。

## 修改内容

- DEBUG 任务整体验证终止、节点强制终止时，按任务关系递归撤销仍在运行的子任务。
- 子画布节点指纹纳入循环配置、内部流程和内部输出定义；依赖分析纳入循环参数及内部展示变量。
- 调试同步可显式读取循环聚合输出，同时保持普通任务节点详情的默认过滤行为不变。
- 子画布节点本身支持 Mock 输出、整体单步调试和全局调试。
- 子画布内部节点暂不支持单步调试，接口返回明确提示。

## 验证

- Interface 调试相关测试：71 passed
- Engine 节点/任务操作及新增兼容用例：57 passed
- pre-commit：black、isort、flake8、pyupgrade 全部通过

## 限制

本次只支持把子画布当作一个整体节点调试，不支持对子画布内部节点执行单步调试。