### PR TITLE
fix(interface): 兼容未升级 engine 缺少子任务查询路由 --story=137858856

### DIFF
--- a/bkflow/interface/task/engine_compat.py
+++ b/bkflow/interface/task/engine_compat.py
@@ -1,0 +1,61 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
+Copyright (C) 2024 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+
+to the current version of the project delivered to anyone in the future.
+"""
+
+import logging
+import re
+
+logger = logging.getLogger("root")
+
+_MISSING_ROUTE_STATUS = re.compile(r"status_code:\s*(404|405)\b")
+
+
+def is_engine_route_missing(result):
+    """判断 engine 调用失败是否因为目标路由不存在（未升级的旧 engine）。"""
+    if not isinstance(result, dict) or result.get("result") is not False:
+        return False
+    return bool(_MISSING_ROUTE_STATUS.search(str(result.get("message") or "")))
+
+
+def empty_wrapped_result(data):
+    """构造与已升级 engine（SimpleGenericViewSet 包装）一致的成功结构。"""
+    return {"result": True, "data": data, "code": "0", "message": ""}
+
+
+def fallback_if_engine_route_missing(result, fallback):
+    """旧 engine 缺路由时返回 fallback，其它响应原样透传。"""
+    if is_engine_route_missing(result):
+        logger.warning("engine route missing, fallback to compatible empty payload: %s", result.get("message"))
+        return fallback
+    return result
+
+
+def parse_task_ids(task_ids_param):
+    """解析逗号分隔的任务 ID，忽略空值和非法值。"""
+    if not task_ids_param:
+        return []
+    parsed = []
+    for raw in str(task_ids_param).split(","):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            parsed.append(int(raw))
+        except (TypeError, ValueError):
+            continue
+    return parsed

--- a/bkflow/interface/task/view.py
+++ b/bkflow/interface/task/view.py
@@ -35,6 +35,11 @@ from bkflow.contrib.openapi.serializers import (
     TaskEngineAdminSerializer,
 )
 from bkflow.exceptions import APIRequestError
+from bkflow.interface.task.engine_compat import (
+    empty_wrapped_result,
+    fallback_if_engine_route_missing,
+    parse_task_ids,
+)
 from bkflow.interface.task.permissions import (
     ScopePermission,
     TaskMockTokenPermission,
@@ -322,22 +327,26 @@ class TaskInterfaceViewSet(GenericViewSet):
         space_id = self.get_space_id(request)
         client = TaskComponentClient(space_id=space_id, from_superuser=request.user.is_superuser)
         result = client.list_children_taskflow(data={"task_id": task_id, "space_id": space_id})
-        return Response(result)
+        return Response(fallback_if_engine_route_missing(result, empty_wrapped_result({"tasks": [], "relations": {}})))
 
     @action(methods=["GET"], detail=False, url_path="root_task_info")
     def root_task_info(self, request, *args, **kwargs):
         """批量查询任务是否包含子任务"""
         space_id = self.get_space_id(request)
+        task_ids_param = request.query_params.get("task_ids")
         client = TaskComponentClient(space_id=space_id, from_superuser=request.user.is_superuser)
-        result = client.root_task_info(data={"task_ids": request.query_params.get("task_ids"), "space_id": space_id})
-        return Response(result)
+        result = client.root_task_info(data={"task_ids": task_ids_param, "space_id": space_id})
+        fallback = empty_wrapped_result(
+            {"has_children_taskflow": {task_id: False for task_id in parse_task_ids(task_ids_param)}}
+        )
+        return Response(fallback_if_engine_route_missing(result, fallback))
 
     @action(methods=["POST"], detail=False, url_path="get_node_outputs")
     def get_node_outputs(self, request, *args, **kwargs):
         space_id = self.get_space_id(request)
         client = TaskComponentClient(space_id=space_id, from_superuser=request.user.is_superuser)
         result = client.get_node_outputs(data={"space_id": space_id, **request.data})
-        return Response(result)
+        return Response(fallback_if_engine_route_missing(result, empty_wrapped_result([])))
 
     @action(methods=["GET"], detail=False, url_path="get_tasks_pipeline")
     def get_tasks_pipeline(self, request, *args, **kwargs):
@@ -346,7 +355,7 @@ class TaskInterfaceViewSet(GenericViewSet):
         result = client.get_tasks_pipeline(
             data={"space_id": space_id, "task_ids": request.query_params.get("task_ids")}
         )
-        return Response(result)
+        return Response(fallback_if_engine_route_missing(result, empty_wrapped_result({})))
 
     @action(methods=["GET"], detail=False, url_path="batch_get_task_states")
     def batch_get_task_states(self, request, *args, **kwargs):
@@ -355,4 +364,4 @@ class TaskInterfaceViewSet(GenericViewSet):
         result = client.batch_get_task_states(
             data={"space_id": space_id, "task_ids": request.query_params.get("task_ids")}
         )
-        return Response(result)
+        return Response(fallback_if_engine_route_missing(result, empty_wrapped_result({})))

--- a/frontend/src/views/admin/Space/Task/index.vue
+++ b/frontend/src/views/admin/Space/Task/index.vue
@@ -373,15 +373,23 @@ export default {
         },
         // 判断每条记录是否有子流程并且设置
         async setListHaveChild(list) {
-            const ids = list.map(item => item.id);
-            const checkStatus = await this.getTaskHasSubTasks({
-                project_id: this.project_id,
-                task_ids: ids.toString(),
-                space_id: this.spaceId,
-            });
-            list.forEach((item) => {
-                item.isHasChild = checkStatus.data.has_children_taskflow[item.id];
-            });
+            try {
+                const ids = list.map(item => item.id);
+                const checkStatus = await this.getTaskHasSubTasks({
+                    project_id: this.project_id,
+                    task_ids: ids.toString(),
+                    space_id: this.spaceId,
+                });
+                const childrenMap = (checkStatus && checkStatus.data && checkStatus.data.has_children_taskflow) || {};
+                list.forEach((item) => {
+                    item.isHasChild = !!childrenMap[item.id];
+                });
+            } catch (error) {
+                console.warn(error);
+                list.forEach((item) => {
+                    item.isHasChild = false;
+                });
+            }
             return list;
         },
         // 获取当前流程的子流程列表
@@ -406,7 +414,7 @@ export default {
                     curField.width = 20 * (curParent.level + 1) + 100;
                 } else {
                     const res = await this.getTaskHasSubTaskList({ task_id: row.id, space_id: this.spaceId });
-                    const { tasks, relations } = res.data;
+                    const { tasks = [], relations = {} } = (res && res.data) || {};
                     const parentToChildren = {};
                     for (const [childId, parentId] of Object.entries(relations)) {
                         if (!parentToChildren[parentId]) {

--- a/tests/interface/task/test_engine_compat.py
+++ b/tests/interface/task/test_engine_compat.py
@@ -1,0 +1,200 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
+Copyright (C) 2024 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+
+to the current version of the project delivered to anyone in the future.
+"""
+
+from unittest import mock
+from unittest.mock import MagicMock
+
+from bkflow.interface.task.engine_compat import (
+    empty_wrapped_result,
+    fallback_if_engine_route_missing,
+    is_engine_route_missing,
+    parse_task_ids,
+)
+from bkflow.interface.task.view import TaskInterfaceViewSet
+
+ENGINE_404 = {
+    "result": False,
+    "message": (
+        "Request API error, status_code: 404, url: http://engine/task/root_task_info/, method: GET, resp: Not Found"
+    ),
+}
+ENGINE_405 = {
+    "result": False,
+    "message": "Request API error, status_code: 405, url: http://engine/task/get_node_outputs/, method: POST, resp: {}",
+}
+ENGINE_500 = {
+    "result": False,
+    "message": "Request API error, status_code: 500, url: http://engine/task/root_task_info/, method: GET, resp: boom",
+}
+
+
+class TestIsEngineRouteMissing:
+    """识别旧 engine 缺少新路由的失败响应。"""
+
+    def test_detects_404_from_http_client(self):
+        assert is_engine_route_missing(ENGINE_404) is True
+
+    def test_detects_405_from_http_client(self):
+        assert is_engine_route_missing(ENGINE_405) is True
+
+    def test_does_not_swallow_500(self):
+        assert is_engine_route_missing(ENGINE_500) is False
+
+    def test_does_not_treat_success_as_missing(self):
+        assert is_engine_route_missing({"result": True, "data": {"has_children_taskflow": {1: False}}}) is False
+
+    def test_ignores_non_dict(self):
+        assert is_engine_route_missing(None) is False
+        assert is_engine_route_missing("not found") is False
+
+
+class TestFallbackIfEngineRouteMissing:
+    """404/405 回空成功结构，其它结果原样返回。"""
+
+    def test_returns_fallback_on_404(self):
+        fallback = empty_wrapped_result({"tasks": [], "relations": {}})
+        assert fallback_if_engine_route_missing(ENGINE_404, fallback) == fallback
+
+    def test_keeps_success_payload(self):
+        success = {"result": True, "data": {"has_children_taskflow": {1: True}}}
+        assert fallback_if_engine_route_missing(success, empty_wrapped_result({})) == success
+
+    def test_keeps_500_payload(self):
+        assert fallback_if_engine_route_missing(ENGINE_500, empty_wrapped_result({})) == ENGINE_500
+
+
+class TestParseTaskIds:
+    def test_parses_comma_separated_ids(self):
+        assert parse_task_ids("1,2,3") == [1, 2, 3]
+
+    def test_skips_blank_and_invalid(self):
+        assert parse_task_ids("1,,abc,2") == [1, 2]
+
+    def test_empty(self):
+        assert parse_task_ids(None) == []
+        assert parse_task_ids("") == []
+
+
+def _engine_404_message(path):
+    return {
+        "result": False,
+        "message": f"Request API error, status_code: 404, url: http://engine/{path}, method: GET, resp: Not Found",
+    }
+
+
+class TestTaskInterfaceEngineRouteCompat:
+    """interface 在旧 engine 缺路由时回空成功结构，不影响已升级 engine。"""
+
+    def _request(self, query_params=None, data=None):
+        request = MagicMock()
+        request.user.is_superuser = True
+        request.query_params = query_params or {}
+        request.data = data or {}
+        return request
+
+    @mock.patch("bkflow.interface.task.view.TaskComponentClient")
+    def test_root_task_info_falls_back_when_engine_404(self, mock_client_class):
+        mock_client = mock.Mock()
+        mock_client.root_task_info.return_value = ENGINE_404
+        mock_client_class.return_value = mock_client
+
+        view = TaskInterfaceViewSet()
+        view.get_space_id = lambda request: 1
+        response = view.root_task_info(self._request({"task_ids": "11,22", "space_id": "1"}))
+
+        assert response.data["result"] is True
+        assert response.data["data"]["has_children_taskflow"] == {11: False, 22: False}
+
+    @mock.patch("bkflow.interface.task.view.TaskComponentClient")
+    def test_root_task_info_passthrough_when_engine_ok(self, mock_client_class):
+        success = {"result": True, "data": {"has_children_taskflow": {11: True}}, "code": "0", "message": ""}
+        mock_client = mock.Mock()
+        mock_client.root_task_info.return_value = success
+        mock_client_class.return_value = mock_client
+
+        view = TaskInterfaceViewSet()
+        view.get_space_id = lambda request: 1
+        response = view.root_task_info(self._request({"task_ids": "11", "space_id": "1"}))
+
+        assert response.data == success
+
+    @mock.patch("bkflow.interface.task.view.TaskComponentClient")
+    def test_root_task_info_does_not_swallow_500(self, mock_client_class):
+        mock_client = mock.Mock()
+        mock_client.root_task_info.return_value = ENGINE_500
+        mock_client_class.return_value = mock_client
+
+        view = TaskInterfaceViewSet()
+        view.get_space_id = lambda request: 1
+        response = view.root_task_info(self._request({"task_ids": "11", "space_id": "1"}))
+
+        assert response.data["result"] is False
+        assert "status_code: 500" in response.data["message"]
+
+    @mock.patch("bkflow.interface.task.view.TaskComponentClient")
+    def test_list_children_taskflow_falls_back_when_engine_404(self, mock_client_class):
+        mock_client = mock.Mock()
+        mock_client.list_children_taskflow.return_value = _engine_404_message("task/list_children_taskflow/")
+        mock_client_class.return_value = mock_client
+
+        view = TaskInterfaceViewSet()
+        view.get_space_id = lambda request: 1
+        response = view.list_children_taskflow(self._request({"space_id": "1"}), task_id=99)
+
+        assert response.data["result"] is True
+        assert response.data["data"] == {"tasks": [], "relations": {}}
+
+    @mock.patch("bkflow.interface.task.view.TaskComponentClient")
+    def test_get_node_outputs_falls_back_when_engine_404(self, mock_client_class):
+        mock_client = mock.Mock()
+        mock_client.get_node_outputs.return_value = _engine_404_message("task/get_node_outputs/")
+        mock_client_class.return_value = mock_client
+
+        view = TaskInterfaceViewSet()
+        view.get_space_id = lambda request: 1
+        response = view.get_node_outputs(self._request(data={"space_id": 1, "task_id": 1, "node_ids": ["n1"]}))
+
+        assert response.data["result"] is True
+        assert response.data["data"] == []
+
+    @mock.patch("bkflow.interface.task.view.TaskComponentClient")
+    def test_get_tasks_pipeline_falls_back_when_engine_404(self, mock_client_class):
+        mock_client = mock.Mock()
+        mock_client.get_tasks_pipeline.return_value = _engine_404_message("task/get_tasks_pipeline/")
+        mock_client_class.return_value = mock_client
+
+        view = TaskInterfaceViewSet()
+        view.get_space_id = lambda request: 1
+        response = view.get_tasks_pipeline(self._request({"space_id": "1", "task_ids": "1"}))
+
+        assert response.data["result"] is True
+        assert response.data["data"] == {}
+
+    @mock.patch("bkflow.interface.task.view.TaskComponentClient")
+    def test_batch_get_task_states_falls_back_when_engine_404(self, mock_client_class):
+        mock_client = mock.Mock()
+        mock_client.batch_get_task_states.return_value = _engine_404_message("task/batch_get_task_states/")
+        mock_client_class.return_value = mock_client
+
+        view = TaskInterfaceViewSet()
+        view.get_space_id = lambda request: 1
+        response = view.batch_get_task_states(self._request({"space_id": "1", "task_ids": "1"}))
+
+        assert response.data["result"] is True
+        assert response.data["data"] == {}


### PR DESCRIPTION
## Summary

- 只发 interface、部分 engine 未升级时，管理端任务列表每次加载都会打 `root_task_info`；旧 engine 返回 404 会导致「是否有子任务」失败，整表刷不出来。
- interface 对 `root_task_info` / `list_children_taskflow` / `get_node_outputs` / `get_tasks_pipeline` / `batch_get_task_states` 仅在 engine 返回 404/405 时回空成功结构（与已升级 engine 的包装一致）；已升级 engine 的正常响应和 500 原样透传，存量任务执行路径不变。
- 管理端任务列表对缺失的 `has_children_taskflow` / 子任务列表数据做兜底，避免二次把列表打挂。

## Test plan

- [ ] 只发 interface、engine 未升级：空间管理任务列表能刷新，存量任务「是否有子任务」显示为否，列表不空白
- [ ] 只发 interface、engine 未升级：展开子任务时不报错、不阻断存量任务详情/操作
- [ ] interface + 已升级 engine：有子任务的任务仍能正确标记并展开；子画布相关查询与现网一致
- [ ] engine 真实 500：上述接口仍返回失败，不吞错误
- [ ] 存量普通任务创建、执行、节点操作不受影响

TAPD: https://tapd.woa.com/70120217/prong/stories/view/137858856

Made with [Cursor](https://cursor.com)