### PR TITLE
fix(interface): 兼容旧 engine 任务列表缺少 labels 字段 --story=137862726

### DIFF
--- a/bkflow/apigw/views/get_task_list.py
+++ b/bkflow/apigw/views/get_task_list.py
@@ -24,6 +24,7 @@ from django.views.decorators.http import require_GET
 from bkflow.apigw.decorators import check_jwt_and_space, return_json_response
 from bkflow.apigw.serializers.task import GetTaskListSerializer
 from bkflow.contrib.api.collections.task import TaskComponentClient
+from bkflow.interface.task.engine_compat import enrich_task_list_result_labels
 from bkflow.label.models import Label
 
 
@@ -62,15 +63,4 @@ def get_task_list(request, space_id):
         data["label"] = ",".join([str(label_id) for label_id in label_ids])
 
     client = TaskComponentClient(space_id=space_id)
-    result = client.task_list(data=data)
-    if result.get("result"):
-        label_ids = []
-        for item in result["data"]["results"]:
-            label_ids.extend(item["labels"])
-
-        labels_map = Label.objects.get_labels_map(set(label_ids))
-
-        for item in result["data"]["results"]:
-            item["labels"] = [labels_map.get(label_id) for label_id in item["labels"]]
-
-    return result
+    return enrich_task_list_result_labels(client.task_list(data=data))

--- a/bkflow/interface/task/engine_compat.py
+++ b/bkflow/interface/task/engine_compat.py
@@ -45,6 +45,29 @@ def fallback_if_engine_route_missing(result, fallback):
     return result
 
 
+def enrich_task_list_result_labels(result, labels_map_getter=None):
+    """将任务列表中的 label id 转成标签对象；旧 engine 无 labels 字段时视为空。"""
+    if not isinstance(result, dict) or not result.get("result"):
+        return result
+    results = (result.get("data") or {}).get("results")
+    if not results:
+        return result
+
+    label_ids = []
+    for item in results:
+        label_ids.extend(item.get("labels") or [])
+
+    if labels_map_getter is None:
+        from bkflow.label.models import Label
+
+        labels_map_getter = Label.objects.get_labels_map
+    labels_map = labels_map_getter(set(label_ids)) if label_ids else {}
+
+    for item in results:
+        item["labels"] = [labels_map.get(label_id) for label_id in (item.get("labels") or [])]
+    return result
+
+
 def parse_task_ids(task_ids_param):
     """解析逗号分隔的任务 ID，忽略空值和非法值。"""
     if not task_ids_param:

--- a/bkflow/interface/task/view.py
+++ b/bkflow/interface/task/view.py
@@ -37,6 +37,7 @@ from bkflow.contrib.openapi.serializers import (
 from bkflow.exceptions import APIRequestError
 from bkflow.interface.task.engine_compat import (
     empty_wrapped_result,
+    enrich_task_list_result_labels,
     fallback_if_engine_route_missing,
     parse_task_ids,
 )
@@ -71,17 +72,7 @@ class TaskInterfaceAdminViewSet(GenericViewSet):
         if label_ids:
             query_params["label"] = ",".join([str(label_id) for label_id in label_ids])
         result = client.task_list(data={**query_params, "space_id": space_id})
-
-        label_ids = []
-        for item in result["data"]["results"]:
-            label_ids.extend(item["labels"])
-
-        labels_map = Label.objects.get_labels_map(set(label_ids))
-
-        for item in result["data"]["results"]:
-            item["labels"] = [labels_map.get(label_id) for label_id in item["labels"]]
-
-        return Response(result)
+        return Response(enrich_task_list_result_labels(result))
 
     @action(methods=["POST"], detail=False, url_path="update_labels/(?P<space_id>\\d+)/(?P<pk>\\d+)")
     def update_labels(self, request, space_id, pk=None):

--- a/tests/interface/task/test_engine_compat.py
+++ b/tests/interface/task/test_engine_compat.py
@@ -22,11 +22,12 @@ from unittest.mock import MagicMock
 
 from bkflow.interface.task.engine_compat import (
     empty_wrapped_result,
+    enrich_task_list_result_labels,
     fallback_if_engine_route_missing,
     is_engine_route_missing,
     parse_task_ids,
 )
-from bkflow.interface.task.view import TaskInterfaceViewSet
+from bkflow.interface.task.view import TaskInterfaceAdminViewSet, TaskInterfaceViewSet
 
 ENGINE_404 = {
     "result": False,
@@ -198,3 +199,77 @@ class TestTaskInterfaceEngineRouteCompat:
 
         assert response.data["result"] is True
         assert response.data["data"] == {}
+
+
+class TestEnrichTaskListResultLabels:
+    """任务列表 labels 兼容：缺字段当空，失败响应原样返回。"""
+
+    def test_fills_empty_labels_for_legacy_engine_items(self):
+        result = {"result": True, "data": {"results": [{"id": 1, "name": "legacy"}]}}
+        enrich_task_list_result_labels(result, labels_map_getter=lambda ids: {})
+        assert result["data"]["results"][0]["labels"] == []
+
+    def test_passthrough_failed_engine_result(self):
+        failed = {"result": False, "message": "boom"}
+        assert enrich_task_list_result_labels(failed, labels_map_getter=lambda ids: {}) == failed
+
+
+class TestGetTaskListOldEngineLabels:
+    """旧 engine 任务列表没有 labels 时，管理端列表不能 500。"""
+
+    def _request(self, query_params=None):
+        params = dict(query_params or {})
+        request = MagicMock()
+        request.query_params = MagicMock()
+        request.query_params.copy.return_value = params
+        request.query_params.get.side_effect = params.get
+        return request
+
+    @mock.patch("bkflow.interface.task.view.Label.get_label_ids_by_names", return_value=[])
+    @mock.patch("bkflow.interface.task.view.Label.objects.get_labels_map")
+    @mock.patch("bkflow.interface.task.view.TaskComponentClient")
+    def test_get_task_list_tolerates_missing_labels(self, mock_client_class, mock_get_labels_map, _mock_ids):
+        mock_get_labels_map.return_value = {}
+        mock_client = mock.Mock()
+        mock_client.task_list.return_value = {
+            "result": True,
+            "data": {"results": [{"id": 2401, "name": "legacy task"}]},
+        }
+        mock_client_class.return_value = mock_client
+
+        response = TaskInterfaceAdminViewSet().get_task_list(self._request({"space_id": "240"}), space_id=240)
+
+        assert response.data["result"] is True
+        assert response.data["data"]["results"][0]["id"] == 2401
+        assert response.data["data"]["results"][0]["labels"] == []
+
+    @mock.patch("bkflow.interface.task.view.Label.get_label_ids_by_names", return_value=[])
+    @mock.patch("bkflow.interface.task.view.Label.objects.get_labels_map")
+    @mock.patch("bkflow.interface.task.view.TaskComponentClient")
+    def test_get_task_list_keeps_existing_labels(self, mock_client_class, mock_get_labels_map, _mock_ids):
+        mock_get_labels_map.return_value = {7: {"id": 7, "name": "prod"}}
+        mock_client = mock.Mock()
+        mock_client.task_list.return_value = {
+            "result": True,
+            "data": {"results": [{"id": 1, "name": "new engine task", "labels": [7]}]},
+        }
+        mock_client_class.return_value = mock_client
+
+        response = TaskInterfaceAdminViewSet().get_task_list(self._request({}), space_id=1)
+
+        assert response.data["data"]["results"][0]["labels"] == [{"id": 7, "name": "prod"}]
+        mock_get_labels_map.assert_called_once_with({7})
+
+    @mock.patch("bkflow.interface.task.view.Label.get_label_ids_by_names", return_value=[])
+    @mock.patch("bkflow.interface.task.view.Label.objects.get_labels_map")
+    @mock.patch("bkflow.interface.task.view.TaskComponentClient")
+    def test_get_task_list_passthrough_when_engine_fails(self, mock_client_class, mock_get_labels_map, _mock_ids):
+        failed = {"result": False, "message": "Request API error, status_code: 500, url: http://engine/task/"}
+        mock_client = mock.Mock()
+        mock_client.task_list.return_value = failed
+        mock_client_class.return_value = mock_client
+
+        response = TaskInterfaceAdminViewSet().get_task_list(self._request({}), space_id=1)
+
+        assert response.data == failed
+        mock_get_labels_map.assert_not_called()


### PR DESCRIPTION
## Summary

- 预发只发 interface、engine 未升级时，空间管理任务列表 `GET /task_admin/get_task_list/240/` 返回 500，整表刷不出来。
- 根因：新 interface 假定 engine 每条任务都带 `labels`；旧 engine 列表项没有该字段，`item[\"labels\"]` 触发 `KeyError`。#904 只兼容了子任务查询路由，盖不住这条列表接口。
- interface / APIGW `get_task_list` 统一用兼容逻辑：缺 `labels` 按空列表处理；engine 失败响应原样透传。已升级 engine 的标签回显不变。

## Test plan

- [ ] 只发 interface、旧 engine：空间 240 任务列表能刷新，不再 500
- [ ] 已升级 engine：带标签的任务仍能正确回显标签
- [ ] engine 真实失败：`get_task_list` 返回失败，不转成 500
- [ ] APIGW `get_task_list` 在旧 engine 下同样不因缺 labels 500

TAPD: https://tapd.woa.com/70120217/prong/stories/view/137862726

Made with [Cursor](https://cursor.com)