### PR TITLE
fix(interface): SPA 入口补发 CSRF cookie --story=137864077

### DIFF
--- a/bkflow/interface/views.py
+++ b/bkflow/interface/views.py
@@ -31,7 +31,7 @@ from django.contrib.auth import logout
 from django.http import JsonResponse
 from django.shortcuts import render
 from django.utils.translation import ugettext_lazy as _
-from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 from django.views.decorators.http import require_GET, require_POST
 
 from bkflow.contrib.api.collections.task import TaskComponentClient
@@ -42,6 +42,7 @@ from bkflow.task.open_plugin_callback import OPEN_PLUGIN_CALLBACK_TOKEN_META_KEY
 logger = logging.getLogger("root")
 
 
+@ensure_csrf_cookie
 def home(request):
     return render(request, "base_vue.html")
 
@@ -54,6 +55,7 @@ def user_exit(request):
     return handler.build_401_response(request)
 
 
+@ensure_csrf_cookie
 def is_admin_or_space_superuser(request):
     """
     判断是否是管理员或者空间超级管理员
@@ -72,6 +74,7 @@ def is_admin_or_space_superuser(request):
     )
 
 
+@ensure_csrf_cookie
 def is_admin_or_current_space_superuser(request):
     """
     判断是否是管理员或者当前空间超级管理员

--- a/bkflow/utils/django_error_hanlder.py
+++ b/bkflow/utils/django_error_hanlder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 TencentBlueKing is pleased to support the open source community by making
 蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
@@ -23,8 +22,10 @@ from blueapps.account.middlewares import LoginRequiredMiddleware
 from django.conf import settings
 from django.http import HttpResponseNotFound, HttpResponseRedirect
 from django.shortcuts import render
+from django.views.decorators.csrf import ensure_csrf_cookie
 
 
+@ensure_csrf_cookie
 def page_not_found(request, exception):
     if request.path.startswith(settings.STATIC_URL):
         return HttpResponseNotFound()

--- a/tests/interface/test_csrf_cookie.py
+++ b/tests/interface/test_csrf_cookie.py
@@ -1,0 +1,68 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
+Copyright (C) 2024 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+
+to the current version of the project delivered to anyone in the future.
+"""
+
+from unittest import mock
+from unittest.mock import MagicMock
+
+from django.test import RequestFactory
+
+from bkflow.interface.views import (
+    home,
+    is_admin_or_current_space_superuser,
+    is_admin_or_space_superuser,
+)
+from bkflow.utils.django_error_hanlder import page_not_found
+
+
+def _request(path, user=None, get_params=None):
+    request = RequestFactory().get(path, data=get_params or {})
+    request.user = user or MagicMock(username="admin", is_superuser=True)
+    return request
+
+
+class TestSpaEntriesEnsureCsrfCookie:
+    """管理端 SPA 首屏 GET 必须下发 CSRF cookie，否则保存配置 / 任务列表 POST 会失败。"""
+
+    @mock.patch("bkflow.interface.views.Space.objects.filter")
+    @mock.patch("bkflow.interface.views.SpaceConfig.objects.get_space_ids_of_superuser", return_value=[])
+    def test_is_admin_user_marks_csrf_cookie(self, _mock_ids, _mock_filter):
+        request = _request("/is_admin_user/")
+        is_admin_or_space_superuser(request)
+        assert request.META.get("CSRF_COOKIE_USED") is True
+
+    @mock.patch("bkflow.interface.views.SpaceConfig.objects.filter")
+    def test_is_current_space_admin_marks_csrf_cookie(self, mock_filter):
+        mock_filter.return_value.exists.return_value = False
+        request = _request("/is_current_space_admin/", get_params={"space_id": "240"})
+        is_admin_or_current_space_superuser(request)
+        assert request.META.get("CSRF_COOKIE_USED") is True
+
+    @mock.patch("bkflow.interface.views.render", return_value=MagicMock())
+    def test_home_marks_csrf_cookie(self, _mock_render):
+        request = _request("/")
+        home(request)
+        assert request.META.get("CSRF_COOKIE_USED") is True
+
+    @mock.patch("bkflow.utils.django_error_hanlder.render", return_value=MagicMock())
+    @mock.patch("bkflow.utils.django_error_hanlder.LoginRequiredMiddleware")
+    def test_page_not_found_marks_csrf_cookie(self, mock_middleware_cls, _mock_render):
+        mock_middleware_cls.return_value.authenticate.return_value = MagicMock(username="admin")
+        request = _request("/bkflow_engine_admin/")
+        page_not_found(request, exception=None)
+        assert request.META.get("CSRF_COOKIE_USED") is True


### PR DESCRIPTION
## Summary

- 预发空间 240 保存空间配置（PATCH `/api/space/admin/space_config/329/`，superusers）报 `CSRF Failed: CSRF cookie not set`（trace `ade2bacfcca7c6403517528a93e8d152`）。
- 任务列表「访问异常 / 仅提供从已认证平台发起访问」是前端对 **任意 HTTP 403** 的通用弹窗，不是独立的平台准入校验。缺 CSRF cookie 时，列表里的 `POST task_admin/get_tasks_states/` 会 403，从而弹出这个框。
- SPA 从 `/bkflow_engine_admin/` 走 404 回退，home / 首屏 `is_admin_user` 都没有 `ensure_csrf_cookie`，新会话只有登录 cookie、没有 CSRF cookie。本次给这些入口补上。

## Test plan

- [ ] 硬刷新 `/bkflow_engine_admin/?space_id=240&activeTab=config` 后，浏览器能看到 `{APP_CODE}_csrftoken` cookie
- [ ] 保存空间配置（含已有配置的 PATCH）不再报 CSRF cookie not set
- [ ] 打开任务列表不再出现「访问异常」403 弹窗
- [ ] 已登录、已有 CSRF cookie 的会话，保存和列表行为不变

TAPD: https://tapd.woa.com/70120217/prong/stories/view/137864077

Made with [Cursor](https://cursor.com)