### PR TITLE
fix(interface): 兼容旧 engine 包装后的缺路由 404 --story=137864681

### DIFF
--- a/bkflow/interface/task/engine_compat.py
+++ b/bkflow/interface/task/engine_compat.py
@@ -23,13 +23,24 @@ import re
 logger = logging.getLogger("root")
 
 _MISSING_ROUTE_STATUS = re.compile(r"status_code:\s*(404|405)\b")
+# SimpleGenericViewSet 会把 DRF NotFound 改写成 HTTP 200 + code=not_found
+_DEFAULT_NOT_FOUND_MESSAGES = {"未找到。", "Not found."}
 
 
 def is_engine_route_missing(result):
     """判断 engine 调用失败是否因为目标路由不存在（未升级的旧 engine）。"""
     if not isinstance(result, dict) or result.get("result") is not False:
         return False
-    return bool(_MISSING_ROUTE_STATUS.search(str(result.get("message") or "")))
+    message = str(result.get("message") or "")
+    if _MISSING_ROUTE_STATUS.search(message):
+        return True
+    detail = ""
+    data = result.get("data")
+    if isinstance(data, dict):
+        detail = str(data.get("detail") or "")
+    return result.get("code") == "not_found" and (
+        message in _DEFAULT_NOT_FOUND_MESSAGES or detail in _DEFAULT_NOT_FOUND_MESSAGES
+    )
 
 
 def empty_wrapped_result(data):

--- a/tests/interface/task/test_engine_compat.py
+++ b/tests/interface/task/test_engine_compat.py
@@ -43,6 +43,25 @@ ENGINE_500 = {
     "result": False,
     "message": "Request API error, status_code: 500, url: http://engine/task/root_task_info/, method: GET, resp: boom",
 }
+# 旧 engine 有 SimpleGenericViewSet：缺路由的 DRF 404 会被改写成 HTTP 200
+ENGINE_WRAPPED_NOT_FOUND = {
+    "result": False,
+    "data": {"detail": "未找到。"},
+    "code": "not_found",
+    "message": "未找到。",
+}
+ENGINE_WRAPPED_NOT_FOUND_EN = {
+    "result": False,
+    "data": {"detail": "Not found."},
+    "code": "not_found",
+    "message": "Not found.",
+}
+ENGINE_CUSTOM_NOT_FOUND = {
+    "result": False,
+    "data": {"detail": "task 123 not found"},
+    "code": "not_found",
+    "message": "task 123 not found",
+}
 
 
 class TestIsEngineRouteMissing:
@@ -63,6 +82,15 @@ class TestIsEngineRouteMissing:
     def test_ignores_non_dict(self):
         assert is_engine_route_missing(None) is False
         assert is_engine_route_missing("not found") is False
+
+    def test_detects_wrapped_drf_not_found(self):
+        assert is_engine_route_missing(ENGINE_WRAPPED_NOT_FOUND) is True
+
+    def test_detects_wrapped_english_not_found(self):
+        assert is_engine_route_missing(ENGINE_WRAPPED_NOT_FOUND_EN) is True
+
+    def test_does_not_swallow_custom_not_found_message(self):
+        assert is_engine_route_missing(ENGINE_CUSTOM_NOT_FOUND) is False
 
 
 class TestFallbackIfEngineRouteMissing:
@@ -147,6 +175,19 @@ class TestTaskInterfaceEngineRouteCompat:
 
         assert response.data["result"] is False
         assert "status_code: 500" in response.data["message"]
+
+    @mock.patch("bkflow.interface.task.view.TaskComponentClient")
+    def test_root_task_info_falls_back_when_engine_wraps_not_found(self, mock_client_class):
+        mock_client = mock.Mock()
+        mock_client.root_task_info.return_value = ENGINE_WRAPPED_NOT_FOUND
+        mock_client_class.return_value = mock_client
+
+        view = TaskInterfaceViewSet()
+        view.get_space_id = lambda request: 1
+        response = view.root_task_info(self._request({"task_ids": "2,1", "space_id": "240"}))
+
+        assert response.data["result"] is True
+        assert response.data["data"]["has_children_taskflow"] == {2: False, 1: False}
 
     @mock.patch("bkflow.interface.task.view.TaskComponentClient")
     def test_list_children_taskflow_falls_back_when_engine_404(self, mock_client_class):


### PR DESCRIPTION
## Summary

- 预发空间 240 任务列表已能刷出，但仍 toast「未找到。」（trace `2c31abc5c8aa47273feb60e8f808afc4`）。
- 空间走 **gray-engine**。interface 调 `GET /task/root_task_info/?task_ids=2,1`，旧 engine 没有该 action。
- DRF 404「未找到。」被 engine 的 `SimpleGenericViewSet` 改写成 HTTP 200 `{result:false, code:not_found, message:未找到。}`。#904 只认 HTTP client 文案里的 `status_code: 404/405`，漏掉这种包装形态；前端 axios 对 `result:false` 弹 toast。
- 本次把 DRF 默认「未找到。」/「Not found.」纳入缺路由识别，回空 `has_children_taskflow`。自定义 404 文案和 500 仍透传。

## Test plan

- [ ] 空间 240（gray-engine 未升级）打开 `/bkflow_engine_admin/?space_id=240&activeTab=task`，任务列表能刷出且不再 toast「未找到。」
- [ ] 已升级 engine 的空间，有子任务的任务仍显示展开三角
- [ ] engine 500 时仍应报错，不能被吞成空列表

TAPD: https://tapd.woa.com/70120217/prong/stories/view/137864681

Made with [Cursor](https://cursor.com)