### PR TITLE
chore(ci): 将 AI 代码审查模型切换为 GLM-5.3

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -146,9 +146,9 @@ jobs:
             echo "❌ codebuddy 命令未找到"
             exit 1
           fi
-          CODEBUDDY_CMD="codebuddy -p --dangerously-skip-permissions --model claude-opus-4.6"
+          CODEBUDDY_CMD="codebuddy -p --dangerously-skip-permissions --model glm-5.3-ioa"
           if ! command -v codebuddy &> /dev/null; then
-            CODEBUDDY_CMD="cbc -p --dangerously-skip-permissions --model claude-opus-4.6"
+            CODEBUDDY_CMD="cbc -p --dangerously-skip-permissions --model glm-5.3-ioa"
           fi
           echo "🔍 验证 CodeBuddy CLI 连通性..."
           VERIFY_RESULT=$($CODEBUDDY_CMD "回复ok" 2>&1) || true


### PR DESCRIPTION
现有 GitHub Actions AI 代码审查固定使用 `claude-opus-4.6`，本次切换为司内 CodeBuddy 通道的 `glm-5.3-ioa`。

同步调整 `codebuddy` 主命令与 `cbc` 回退命令，使连通性检查和正式审查都使用 GLM-5.3，沿用现有 iOA 通道、仓库密钥与项目审查规范。

验证：
- YAML 解析、全部 `run` 脚本的 `bash -n`、`git diff --check` 通过。
- 确认变更仅包含 `.github/workflows/code_review.yml` 中两处模型参数替换。
- CodeBuddy CLI 2.147.0 使用当前用户的 CodeBuddy 密钥实调成功，返回模型标识 `glm-5.3-ioa` 和预期响应。该验证未使用 GitHub Actions Secret。

工作流使用 `pull_request_target`：此 PR 自身触发的审查仍执行目标分支版本；合并后新触发的审查才会使用 GLM-5.3。
