### PR TITLE
fix(task): 修复特殊 Python 输出导致节点详情 500 --bug=163765931

### DIFF
--- a/bkflow/interface/task/view.py
+++ b/bkflow/interface/task/view.py
@@ -56,6 +56,7 @@ from bkflow.space.configs import SuperusersConfig
 from bkflow.space.models import SpaceConfig
 from bkflow.space.permissions import SpaceSuperuserPermission
 from bkflow.utils.permissions import AdminPermission
+from bkflow.utils.renderers import NodeDetailJSONRenderer
 from bkflow.utils.trace import CallFrom, append_attributes, start_trace
 from bkflow.utils.webhook import get_webhook_delivery_history_by_delivery_id
 
@@ -229,7 +230,12 @@ class TaskInterfaceViewSet(GenericViewSet):
             result = client.operate_task(task_id, operation, request.data)
             return Response(result)
 
-    @action(methods=["GET"], detail=False, url_path="get_task_node_detail/(?P<task_id>\\w+)/node/(?P<node_id>\\w+)")
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path="get_task_node_detail/(?P<task_id>\\w+)/node/(?P<node_id>\\w+)",
+        renderer_classes=[NodeDetailJSONRenderer],
+    )
     def get_task_node_detail(self, request, task_id, node_id, *args, **kwargs):
         space_id = self.get_space_id(request)
         client = TaskComponentClient(space_id=space_id, from_superuser=request.user.is_superuser)

--- a/bkflow/interface/task/view.py
+++ b/bkflow/interface/task/view.py
@@ -56,7 +56,7 @@ from bkflow.space.configs import SuperusersConfig
 from bkflow.space.models import SpaceConfig
 from bkflow.space.permissions import SpaceSuperuserPermission
 from bkflow.utils.permissions import AdminPermission
-from bkflow.utils.renderers import NodeDetailJSONRenderer
+from bkflow.utils.renderers import get_node_detail_renderer_classes
 from bkflow.utils.trace import CallFrom, append_attributes, start_trace
 from bkflow.utils.webhook import get_webhook_delivery_history_by_delivery_id
 
@@ -234,7 +234,7 @@ class TaskInterfaceViewSet(GenericViewSet):
         methods=["GET"],
         detail=False,
         url_path="get_task_node_detail/(?P<task_id>\\w+)/node/(?P<node_id>\\w+)",
-        renderer_classes=[NodeDetailJSONRenderer],
+        renderer_classes=get_node_detail_renderer_classes(),
     )
     def get_task_node_detail(self, request, task_id, node_id, *args, **kwargs):
         space_id = self.get_space_id(request)

--- a/bkflow/task/views.py
+++ b/bkflow/task/views.py
@@ -82,6 +82,7 @@ from bkflow.task.serializers import (
 from bkflow.utils.handlers import handle_plain_log
 from bkflow.utils.mixins import BKFLOWCommonMixin
 from bkflow.utils.permissions import AdminPermission, AppInternalPermission
+from bkflow.utils.renderers import NodeDetailJSONRenderer
 from bkflow.utils.trace import start_trace
 from bkflow.utils.views import SimpleGenericViewSet
 
@@ -576,7 +577,12 @@ class TaskInstanceViewSet(
     @swagger_auto_schema(
         methods=["get"], operation_description="任务节点详情查询", query_serializer=GetNodeDetailQuerySerializer
     )
-    @action(detail=True, methods=["get"], url_path="get_task_node_detail/(?P<node_id>\\w+)")
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path="get_task_node_detail/(?P<node_id>\\w+)",
+        renderer_classes=[NodeDetailJSONRenderer],
+    )
     @validate_task_info
     def get_node_detail(self, request, node_id, *args, **kwargs):
         query_ser = GetNodeDetailQuerySerializer(data=request.query_params)

--- a/bkflow/task/views.py
+++ b/bkflow/task/views.py
@@ -82,7 +82,7 @@ from bkflow.task.serializers import (
 from bkflow.utils.handlers import handle_plain_log
 from bkflow.utils.mixins import BKFLOWCommonMixin
 from bkflow.utils.permissions import AdminPermission, AppInternalPermission
-from bkflow.utils.renderers import NodeDetailJSONRenderer
+from bkflow.utils.renderers import get_node_detail_renderer_classes
 from bkflow.utils.trace import start_trace
 from bkflow.utils.views import SimpleGenericViewSet
 
@@ -581,7 +581,7 @@ class TaskInstanceViewSet(
         detail=True,
         methods=["get"],
         url_path="get_task_node_detail/(?P<node_id>\\w+)",
-        renderer_classes=[NodeDetailJSONRenderer],
+        renderer_classes=get_node_detail_renderer_classes(),
     )
     @validate_task_info
     def get_node_detail(self, request, node_id, *args, **kwargs):

--- a/bkflow/utils/renderers.py
+++ b/bkflow/utils/renderers.py
@@ -1,0 +1,74 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
+Copyright (C) 2024 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+
+to the current version of the project delivered to anyone in the future.
+"""
+
+import math
+
+from rest_framework.renderers import JSONRenderer
+from rest_framework.utils.encoders import JSONEncoder
+
+
+def _prepare_display_value(value):
+    """复制 JSON 容器，将非有限数值及含不支持键的字典转换为展示文本。"""
+    if isinstance(value, float) and not math.isfinite(value):
+        return repr(value)
+    if isinstance(value, dict):
+        if any(
+            (key is not None and not isinstance(key, (str, int, float, bool)))
+            or (isinstance(key, float) and not math.isfinite(key))
+            for key in value
+        ):
+            # 不逐个 str(key)，避免 tuple 键与同名字符串键相互覆盖。
+            return repr(value)
+        return {key: _prepare_display_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_prepare_display_value(item) for item in value]
+    return value
+
+
+class _DisplayJSONEncoder(JSONEncoder):
+    """沿用 DRF 的类型编码，仅对不能表示的 Python 对象提供展示文本。"""
+
+    def default(self, value):
+        """保留日期等既有行为，兼容 Fraction、非 UTF-8 bytes 等特殊值。"""
+        try:
+            return _prepare_display_value(super().default(value))
+        except (TypeError, ValueError):
+            return repr(value)
+
+
+class _EscapedDisplayJSONRenderer(JSONRenderer):
+    """通过 JSON 转义保留未配对代理字符，不替换或丢弃原字符。"""
+
+    ensure_ascii = True
+    encoder_class = _DisplayJSONEncoder
+
+
+class NodeDetailJSONRenderer(JSONRenderer):
+    """仅用于节点详情 HTTP 响应，不用于执行结果或持久化序列化。"""
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        """普通响应保持不变，特殊值仅在渲染副本中降级展示。"""
+        try:
+            return super().render(data, accepted_media_type, renderer_context)
+        except (TypeError, ValueError):
+            # UnicodeEncodeError/UnicodeDecodeError 也是 ValueError。
+            # engine 返回的 JSON 在 interface 解码后仍可能含代理字符，故两跳均需使用。
+            return _EscapedDisplayJSONRenderer().render(
+                _prepare_display_value(data), accepted_media_type, renderer_context
+            )

--- a/bkflow/utils/renderers.py
+++ b/bkflow/utils/renderers.py
@@ -20,6 +20,7 @@ to the current version of the project delivered to anyone in the future.
 import math
 
 from rest_framework.renderers import JSONRenderer
+from rest_framework.settings import api_settings
 from rest_framework.utils.encoders import JSONEncoder
 
 
@@ -72,3 +73,11 @@ class NodeDetailJSONRenderer(JSONRenderer):
             return _EscapedDisplayJSONRenderer().render(
                 _prepare_display_value(data), accepted_media_type, renderer_context
             )
+
+
+def get_node_detail_renderer_classes():
+    """只替换默认 JSON renderer，保留既有响应格式、顺序及自定义 renderer。"""
+    return [
+        NodeDetailJSONRenderer if renderer is JSONRenderer else renderer
+        for renderer in api_settings.DEFAULT_RENDERER_CLASSES
+    ]

--- a/tests/engine/task/test_node_detail_rendering.py
+++ b/tests/engine/task/test_node_detail_rendering.py
@@ -1,0 +1,68 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
+Copyright (C) 2024 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+
+to the current version of the project delivered to anyone in the future.
+"""
+
+import copy
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from django.conf import settings
+from django.urls import resolve
+from rest_framework.routers import SimpleRouter
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from bkflow.task.operations import OperationResult
+from bkflow.task.views import TaskInstanceViewSet
+from tests.utils.node_detail import NODE_DETAIL_VALUES, node_detail_data
+
+
+@pytest.mark.parametrize("value, expected", NODE_DETAIL_VALUES)
+def test_node_detail_renders_without_mutating_execution_data(value, expected):
+    """真实路由和 renderer 必须接受特殊输出，且不能改变后续执行使用的对象。"""
+    original = copy.deepcopy(value)
+    node_data = node_detail_data(value)
+    router = SimpleRouter()
+    router.register("task", TaskInstanceViewSet, basename="task")
+    path = "/task/123/get_task_node_detail/node_1/"
+    match = resolve(path, urlconf=tuple(router.urls))
+    request = APIRequestFactory().get(path, {"component_code": "python_code"}, HTTP_BKFLOW_INTERNAL_SPACE_ID="1")
+    force_authenticate(request, user=SimpleNamespace(is_superuser=False, username="tester"))
+    request.app_internal_token = settings.APP_INTERNAL_TOKEN
+    task = Mock(space_id=1)
+    task.has_node.return_value = True
+
+    with patch.object(TaskInstanceViewSet, "get_object", return_value=task), patch(
+        "bkflow.task.views.TaskNodeOperation"
+    ) as operation:
+        operation.return_value.get_node_data.return_value = OperationResult(result=True, data=node_data)
+        operation.return_value.get_node_detail.return_value = OperationResult(
+            result=True, data={"state": "FINISHED", "histories": [], "loop": 1}
+        )
+        response = match.func(request, **match.kwargs)
+        response.render()
+
+    result = json.loads(response.content.decode("utf-8"))
+    assert response.status_code == 200
+    assert result["result"] is True
+    assert result["data"]["state"] == "FINISHED"
+    assert result["data"]["outputs"][0]["value"] == expected
+    assert result["data"]["inputs"]["bk_input_vars"]["value"] == expected
+    assert value == original
+    assert node_data["outputs"][0]["value"] is value

--- a/tests/engine/utils/test_node_detail_renderer.py
+++ b/tests/engine/utils/test_node_detail_renderer.py
@@ -1,0 +1,80 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
+Copyright (C) 2024 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+
+to the current version of the project delivered to anyone in the future.
+"""
+
+import datetime
+import json
+from decimal import Decimal
+
+import pytest
+from rest_framework.renderers import JSONRenderer
+
+from bkflow.utils.renderers import NodeDetailJSONRenderer
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        None,
+        {},
+        {"中文😀": "正常中文😀", "lines": "\u2028\u2029", "values": [None, True, 1, 2.5]},
+        {"date": datetime.date(2026, 9, 9), "amount": Decimal("1.50"), "bytes": b"hello", "tuple": (1, 2)},
+    ],
+)
+def test_normal_responses_keep_existing_encoding(data):
+    """普通响应的字节编码、中文及 DRF 日期类型规则均不因兜底逻辑变化。"""
+    assert NodeDetailJSONRenderer().render(data) == JSONRenderer().render(data)
+
+
+@pytest.mark.parametrize("value", ["\ud800", "\udfff", "A\ud800B😀", "literal \\ud800"])
+def test_surrogates_survive_engine_and_interface_rendering(value):
+    """两次真实 JSON 渲染/解析不替换代理字符，也不把字面量反斜线误当转义。"""
+    renderer = NodeDetailJSONRenderer()
+    data = {"output": value}
+    engine_result = json.loads(renderer.render(data).decode("utf-8"))
+    interface_result = json.loads(renderer.render(engine_result).decode("utf-8"))
+    assert interface_result == {"output": value}
+    assert data == {"output": value}
+
+
+def test_unsupported_dict_keys_in_nested_sequences_remain_distinguishable():
+    """嵌套容器中不支持的键以整个字典文本展示，不合并不同类型的同名键。"""
+    value = [{"nested": ({(1, 2): "tuple", "(1, 2)": "text"},)}]
+    result = json.loads(NodeDetailJSONRenderer().render(value))
+    assert result == [{"nested": ["{(1, 2): 'tuple', '(1, 2)': 'text'}"]}]
+    assert isinstance(value[0]["nested"], tuple)
+    assert len(value[0]["nested"][0]) == 2
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [(float("nan"), "nan"), (float("inf"), "inf"), (float("-inf"), "-inf"), (Decimal("NaN"), "nan")],
+)
+def test_nonfinite_values_are_displayed_as_text(value, expected):
+    """JSON 不接受的非有限数值仅转换展示副本，包含 DRF 对 Decimal 的转换结果。"""
+    data = {"value": value, "surrogate": "\ud800"}
+    result = json.loads(NodeDetailJSONRenderer().render(data))
+    assert result == {"value": expected, "surrogate": "\ud800"}
+    assert data["value"] is value
+
+
+def test_nonfinite_dict_keys_do_not_break_strict_json():
+    """非有限字典键不能直接送入 strict JSON，也不能与同名字符串键合并。"""
+    data = {float("inf"): "number", "inf": "text"}
+    assert json.loads(NodeDetailJSONRenderer().render({"value": data})) == {"value": "{inf: 'number', 'inf': 'text'}"}
+    assert len(data) == 2

--- a/tests/interface/statistics/test_summary_tasks.py
+++ b/tests/interface/statistics/test_summary_tasks.py
@@ -1,4 +1,7 @@
-from django.test import TestCase
+from datetime import date, datetime
+from datetime import timezone as datetime_timezone
+
+import pytest
 from django.utils import timezone
 
 from bkflow.statistics.models import (
@@ -8,47 +11,54 @@ from bkflow.statistics.models import (
 from bkflow.statistics.tasks.summary_tasks import _generate_plugin_summary
 
 
-class TestGeneratePluginSummary(TestCase):
-    def test_generate_plugin_summary_keeps_plugin_source_dimension(self):
-        started_time = timezone.now()
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "started_time, expected_period_start",
+    [
+        (datetime(2026, 9, 9, 15, 59, 59, tzinfo=datetime_timezone.utc), date(2026, 9, 9)),
+        (datetime(2026, 9, 9, 16, 0, 0, tzinfo=datetime_timezone.utc), date(2026, 9, 10)),
+    ],
+)
+def test_generate_plugin_summary_keeps_plugin_source_dimension(started_time, expected_period_start):
+    """本地日期跨日的前后均保留插件来源维度，不依赖 CI 执行时刻。"""
+    TaskflowExecutedNodeStatistics.objects.create(
+        task_id=1,
+        space_id=100,
+        component_code="job_execute",
+        plugin_source="builtin",
+        version="1.0.0",
+        plugin_type="uniform_api",
+        node_id="node_1",
+        started_time=started_time,
+        status=True,
+        state="FINISHED",
+    )
+    TaskflowExecutedNodeStatistics.objects.create(
+        task_id=2,
+        space_id=100,
+        component_code="job_execute",
+        plugin_source="third_party",
+        version="1.0.0",
+        plugin_type="uniform_api",
+        node_id="node_2",
+        started_time=started_time,
+        status=False,
+        state="FAILED",
+    )
 
-        TaskflowExecutedNodeStatistics.objects.create(
-            task_id=1,
-            space_id=100,
-            component_code="job_execute",
-            plugin_source="builtin",
-            version="1.0.0",
-            plugin_type="uniform_api",
-            node_id="node_1",
-            started_time=started_time,
-            status=True,
-            state="FINISHED",
-        )
-        TaskflowExecutedNodeStatistics.objects.create(
-            task_id=2,
-            space_id=100,
-            component_code="job_execute",
-            plugin_source="third_party",
-            version="1.0.0",
-            plugin_type="uniform_api",
-            node_id="node_2",
-            started_time=started_time,
-            status=False,
-            state="FAILED",
-        )
+    with timezone.override("Asia/Shanghai"):
+        _generate_plugin_summary("day", timezone.localdate(started_time))
 
-        _generate_plugin_summary("day", started_time.date())
+    summaries = PluginExecutionSummary.objects.filter(
+        period_type="day",
+        period_start=expected_period_start,
+        space_id=100,
+        component_code="job_execute",
+        version="1.0.0",
+    ).order_by("plugin_source")
 
-        summaries = PluginExecutionSummary.objects.filter(
-            period_type="day",
-            period_start=started_time.date(),
-            space_id=100,
-            component_code="job_execute",
-            version="1.0.0",
-        ).order_by("plugin_source")
-
-        assert summaries.count() == 2
-        assert list(summaries.values_list("plugin_source", "execution_count", "failed_count")) == [
-            ("builtin", 1, 0),
-            ("third_party", 1, 1),
-        ]
+    assert summaries.count() == 2
+    assert list(summaries.values_list("plugin_source", "execution_count", "failed_count")) == [
+        ("builtin", 1, 0),
+        ("third_party", 1, 1),
+    ]

--- a/tests/interface/task/test_node_detail_rendering.py
+++ b/tests/interface/task/test_node_detail_rendering.py
@@ -1,0 +1,54 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
+Copyright (C) 2024 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+
+to the current version of the project delivered to anyone in the future.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from django.urls import resolve
+from rest_framework.routers import SimpleRouter
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from bkflow.interface.task.view import TaskInterfaceViewSet
+from tests.utils.node_detail import NODE_DETAIL_VALUES, node_detail_data
+
+
+@pytest.mark.parametrize("value, expected", NODE_DETAIL_VALUES)
+def test_node_detail_proxy_renders_special_values(value, expected):
+    """engine JSON 解码后仍可能含代理字符，不能在 interface 再次触发 500。"""
+    router = SimpleRouter()
+    router.register("task", TaskInterfaceViewSet, basename="task")
+    path = "/task/get_task_node_detail/123/node/node_1/"
+    match = resolve(path, urlconf=tuple(router.urls))
+    request = APIRequestFactory().get(path, {"space_id": "1"})
+    force_authenticate(request, user=SimpleNamespace(is_superuser=True, username="admin"))
+    # 模拟 engine 已将不支持的对象转换为展示值，并经过真实 JSON 编解码。
+    engine_result = json.loads(json.dumps({"result": True, "data": node_detail_data(expected), "message": ""}))
+
+    with patch("bkflow.interface.task.view.TaskComponentClient") as client:
+        client.return_value.get_task_node_detail.return_value = engine_result
+        response = match.func(request, **match.kwargs)
+        response.render()
+
+    result = json.loads(response.content.decode("utf-8"))
+    assert response.status_code == 200
+    assert result["result"] is True
+    assert result["data"]["outputs"][0]["value"] == expected
+    assert result["data"]["inputs"]["bk_input_vars"]["value"] == expected

--- a/tests/interface/task/test_node_detail_rendering.py
+++ b/tests/interface/task/test_node_detail_rendering.py
@@ -22,6 +22,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from django.contrib.auth import get_user_model
 from django.urls import resolve
 from rest_framework.routers import SimpleRouter
 from rest_framework.test import APIRequestFactory, force_authenticate
@@ -52,3 +53,44 @@ def test_node_detail_proxy_renders_special_values(value, expected):
     assert result["result"] is True
     assert result["data"]["outputs"][0]["value"] == expected
     assert result["data"]["inputs"]["bk_input_vars"]["value"] == expected
+
+
+@pytest.mark.parametrize(
+    "accept, response_format, content_type",
+    [
+        ("application/json", None, "application/json"),
+        ("*/*", None, "application/json"),
+        ("application/json", "json", "application/json"),
+        ("text/html", None, "text/html"),
+        ("*/*", "api", "text/html"),
+    ],
+)
+@pytest.mark.parametrize("value", ["compat-value", "compat-value\ud800"])
+def test_node_detail_preserves_existing_response_formats(accept, response_format, content_type, value):
+    """保留 HTML/API 调试访问，并确保其中展示的代理字符同样可安全渲染。"""
+    router = SimpleRouter()
+    router.register("task", TaskInterfaceViewSet, basename="task")
+    path = "/task/get_task_node_detail/123/node/node_1/"
+    match = resolve(path, urlconf=tuple(router.urls))
+    params = {"space_id": "1"}
+    if response_format:
+        params["format"] = response_format
+    request = APIRequestFactory().get(path, params, HTTP_ACCEPT=accept)
+    force_authenticate(request, user=get_user_model()(is_superuser=True, username="admin", is_active=True))
+    engine_result = {"result": True, "data": node_detail_data(value), "message": ""}
+
+    # 仅替换远端 engine 和 HTML 模板读取的环境配置；路由、协商和渲染保持真实。
+    with patch("bkflow.interface.task.view.TaskComponentClient") as client, patch(
+        "bkflow.interface.context_processors.EnvironmentVariables.objects.get_var",
+        side_effect=lambda key, default=None: default,
+    ):
+        client.return_value.get_task_node_detail.return_value = engine_result
+        response = match.func(request, **match.kwargs)
+        response.render()
+
+    assert response.status_code == 200
+    assert response["Content-Type"].split(";")[0] == content_type
+    if content_type == "application/json":
+        assert json.loads(response.content) == engine_result
+    else:
+        assert "compat-value" in response.content.decode("utf-8")

--- a/tests/utils/node_detail.py
+++ b/tests/utils/node_detail.py
@@ -1,0 +1,44 @@
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸流程引擎服务 (BlueKing Flow Engine Service) available.
+Copyright (C) 2024 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+We undertake not to change the open source license (MIT license) applicable
+
+to the current version of the project delivered to anyone in the future.
+"""
+
+from fractions import Fraction
+
+import pytest
+
+NODE_DETAIL_VALUES = [
+    pytest.param({"中文": "正常😀", "list": [None, True, 1, 1.5]}, {"中文": "正常😀", "list": [None, True, 1, 1.5]}, id="json"),
+    pytest.param({"value": "A\ud800B", "key\udfff": "中文😀"}, {"value": "A\ud800B", "key\udfff": "中文😀"}, id="surrogate"),
+    pytest.param(
+        {"mapping": {(1, 2): "tuple", "(1, 2)": "text"}},
+        {"mapping": "{(1, 2): 'tuple', '(1, 2)': 'text'}"},
+        id="tuple-key-with-collision",
+    ),
+    pytest.param(
+        {"fraction": Fraction(2, 3), "bytes": b"\xff"}, {"fraction": "2/3", "bytes": "b'\\xff'"}, id="special-values"
+    ),
+]
+
+
+def node_detail_data(value):
+    """构造与详情接口一致的输入、输出表格和异常字段。"""
+    return {
+        "inputs": {"bk_input_vars": {"value": value}},
+        "outputs": [{"name": "执行结果", "key": "output", "value": value, "preset": True}],
+        "ex_data": "",
+    }


### PR DESCRIPTION
## 背景

作为 #912 的独立后续修复，解决 Python 代码节点执行成功后，打开节点详情仍可能返回 HTTP 500 的问题。

节点输出可能包含未配对 Unicode 代理字符（例如 `chr(0xD800)`）、非 JSON 字典键或其他特殊 Python 值。DRF 默认 renderer 在 JSON/UTF-8 编码阶段抛出异常。仅处理 engine 不够：interface 解码 engine 返回的 JSON 后，代理字符还会在第二次响应渲染时触发同样的问题。

## 修改

- 仅为 engine 和 interface 的节点详情 action 替换默认 JSON renderer，不修改全局配置、权限、路由或执行逻辑；保留既有 HTML/API 调试格式、自定义 renderer 和顺序。engine 默认仍为 JSON-only。
- 普通响应优先使用原 DRF renderer，保持已有编码行为。
- 遇到无法渲染的值时使用展示副本兜底：以 JSON 转义保留代理字符；不能表示为 JSON 的对象、非法 UTF-8 bytes 和非有限数值转为展示文本。
- 含不支持键的字典整体转为展示文本，避免逐个字符串化键后发生覆盖，例如 `(1, 2)` 与 `"(1, 2)"`。
- 不修改持久化值、节点实际输入输出或下游执行使用的对象。特殊值的文本化只用于详情展示。

## 验证

- 新增 renderer 和 engine 真实路由响应渲染测试：18 passed。
- interface 真实路由响应渲染测试：14 passed，包含 JSON、HTML、`format=json/api`、通配 Accept 与代理字符组合。
- 统计测试：2 passed，固定北京时间跨日前后时刻并使用本地日期，保持原有来源维度与计数断言；仅修测试，不改生产统计逻辑。
- 既有节点详情用例：engine 5 passed，interface 1 passed。
- 已验证修复前失败、修复后通过；覆盖代理字符两跳往返、中文/emoji、正常响应字节一致性、tuple 键碰撞、Fraction、非 UTF-8 bytes、NaN/Infinity、Decimal NaN 和原对象不变。
- Black 22.3.0、flake8、git diff --check 通过。

本轮针对性测试共 40 项通过，额外回归 Python 代码节点与配置用例为 105 passed / 1 skipped，脱敏用例 18 passed。

`60e27d1b0` 的完整 Python CI 已通过：[运行记录](https://github.com/TencentBlueKing/BKFlow/actions/runs/34377798565)。迁移专项 21 passed；interface 套件 1746 passed；engine 套件 590 passed / 1 skipped。此前统计测试混用 UTC 日期与本地日期的问题已修正并增加固定边界用例。

前端 CI 首次因 npm 安装报 `Exit handler never called!`，随后 npx 临时获取 ESLint 9 而无法读取项目旧配置；[单独重试后检查通过](https://github.com/TencentBlueKing/BKFlow/actions/runs/34377798586)。本 PR 未修改前端或其 CI 配置。Black/flake8、commitlint、安全扫描和 CLA 均通过。

## 发布说明

需要部署 engine 和 interface 两端。此 PR 未部署，线上原任务的节点详情刷新验收仍待部署后进行；不需要重跑或改写已完成节点的数据。

TAPD: --bug=163765931
