### PR TITLE
fix(debug): 优化空闲态终止提示文案

### DIFF
--- a/bkflow/template/debug/service.py
+++ b/bkflow/template/debug/service.py
@@ -744,7 +744,7 @@ class DebugService:
         """
         ctx = self.get_or_create_context()
         if ctx.status == "idle" or not ctx.active_task_id:
-            raise DebugStateError("当前没有运行中的调试")
+            raise DebugStateError("当前没有调试中的任务")
         active_task_id = ctx.active_task_id
         previous_active_node_id = ctx.active_node_id
         ctx.status = "terminating"

--- a/tests/interface/template/debug/test_views_run_ops.py
+++ b/tests/interface/template/debug/test_views_run_ops.py
@@ -21,7 +21,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIRequestFactory, force_authenticate
 
-from bkflow.template.debug.service import DebugService
+from bkflow.template.debug.service import DebugService, DebugStateError
 from bkflow.template.models import DebugContext, DebugNodeState
 from bkflow.template.views.debug import DebugViewSet
 
@@ -137,6 +137,7 @@ class TestRunOpsViews:
         response = view(request)
         assert response.status_code == 200
         assert response.data["result"] is False
+        assert response.data["data"]["detail"] == "当前没有调试中的任务"
 
     def test_terminate_node_uses_forced_fail_and_resets_node(self, mocker):
         """单节点终止后立即恢复未调试并释放调试锁。"""
@@ -216,3 +217,15 @@ class TestRunOpsViews:
         assert response.status_code == 200
         assert response.data["result"] is False
         assert DebugContext.objects.get(template_id=1).status == "running"
+
+
+def test_terminate_when_idle_uses_debug_task_message(mocker):
+    """空闲态终止应提示当前没有调试中的任务。"""
+    svc = DebugService(template_id=1, space_id=10)
+    mocker.patch.object(
+        svc,
+        "get_or_create_context",
+        return_value=mocker.Mock(status="idle", active_task_id=None),
+    )
+    with pytest.raises(DebugStateError, match="当前没有调试中的任务"):
+        svc.terminate()


### PR DESCRIPTION
## Summary
- 空闲态调用终止调试时，提示由「当前没有运行中的调试」改为「当前没有调试中的任务」
- 补充服务层单测，锁定该提示文案
- TAPD：https://tapd.woa.com/70120217/prong/stories/view/138151822

## Test plan
- [ ] 流程调试空闲态点击终止，接口返回 `当前没有调试中的任务`
- [ ] 有运行中的调试任务时，终止行为与文案保持不变
- [ ] `pytest tests/interface/template/debug/test_views_run_ops.py::test_terminate_when_idle_uses_debug_task_message`


Made with [Cursor](https://cursor.com)